### PR TITLE
HttpResponseBody.HTML is undefined

### DIFF
--- a/Common/HttpHandlers.swift
+++ b/Common/HttpHandlers.swift
@@ -74,7 +74,7 @@ public class HttpHandlers {
                             var response = "<h3>\(filePath)</h3></br><table>"
                             response += files.map({ "<tr><td><a href=\"\(request.url)/\($0)\">\($0)</a></td></tr>"}).joinWithSeparator("")
                             response += "</table>"
-                            return HttpResponse.OK(.HTML(response))
+                            return HttpResponse.OK(.Html(response))
                         } catch  {
                             return HttpResponse.NotFound
                         }


### PR DESCRIPTION
Fix compile error.

```
.../HttpHandlers.swift:77:53: Type 'HttpResponseBody' has no member 'HTML'
```