### PR TITLE
shutdown client sockets instead of release on stop

### DIFF
--- a/Common/HttpServer.swift
+++ b/Common/HttpServer.swift
@@ -82,7 +82,7 @@ public class HttpServer
         self.listenSocket.release()
         HttpServer.lock(self.clientSocketsLock) {
             for socket in self.clientSockets {
-                socket.release()
+                socket.shutdown()
             }
             self.clientSockets.removeAll(keepCapacity: true)
         }

--- a/Common/Socket.swift
+++ b/Common/Socket.swift
@@ -72,6 +72,10 @@ public class Socket : Hashable {
         Socket.release(self.socketFileDescriptor)
     }
     
+    public func shutdown() {
+        Socket.shutdown(self.socketFileDescriptor)
+    }
+    
     public func acceptClientSocket() throws -> Socket {
         var addr = sockaddr(sa_len: 0, sa_family: 0, sa_data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
         var len: socklen_t = 0
@@ -158,8 +162,12 @@ public class Socket : Hashable {
         setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &no_sig_pipe, socklen_t(sizeof(Int32)));
     }
     
+    private class func shutdown(socket: CInt) {
+        Darwin.shutdown(socket, SHUT_RDWR)
+    }
+    
     private class func release(socket: CInt) {
-        shutdown(socket, SHUT_RDWR)
+        Darwin.shutdown(socket, SHUT_RDWR)
         close(socket)
     }
     


### PR DESCRIPTION
`close` (2) call frees file descriptor and let the system reuse the number. And closing clients socket on server stop may cause an issue.

1. Server stop
2. Request processing is not finished
3. Server starts again
4. Another request arrived and `accept` returns the number which was used for client in step 2
5. The client for step 4 receives response for the request being processed at step 2 :boom: 

I found this issue when I am using swifter for unit testing where start/stop server for each test case and writing a timeout test like:

```swift
server["/test"] = {
  NSThread.sleepFormTimeInterval(3)
  return .OK(.STRING("test message"))
}
```

This can be fixed by calling `shutdown` on client sockets on server stop, and let them be `close`d after request processing finished.