### PR TITLE
Added support for routing based on HTTP request methods

### DIFF
--- a/Resources/login.html
+++ b/Resources/login.html
@@ -4,6 +4,7 @@
 		<link rel="shortcut icon" href="/static/img/favicon.png" />
     	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<link href="http://cdn.staticfile.org/twitter-bootstrap/3.3.0/css/bootstrap.min.css" rel="stylesheet" />
+		<script src="http://cdn.staticfile.org/jquery/2.1.4/jquery.min.js"></script>
     	<title>Login</title>
   	</head>
 	<body>

--- a/Sources/Swifter/HttpParser.swift
+++ b/Sources/Swifter/HttpParser.swift
@@ -14,6 +14,7 @@
 enum HttpParserError: ErrorType {
     case ReadBodyFailed(String)
     case InvalidStatusLine(String)
+    case UnknownRequestMethod(String)
 }
 
 class HttpParser {
@@ -25,7 +26,12 @@ class HttpParser {
         if statusLineTokens.count < 3 {
             throw HttpParserError.InvalidStatusLine(statusLine)
         }
-        let method = statusLineTokens[0]
+        
+        // Make sure the request is of a known type
+        guard let method = HttpRequest.Method(rawValue: statusLineTokens[0]) else {
+            throw HttpParserError.UnknownRequestMethod(statusLine)
+        }
+        
         let path = statusLineTokens[1]
         let urlParams = extractUrlParams(path)
         let headers = try readHeaders(socket)

--- a/Sources/Swifter/HttpRequest.swift
+++ b/Sources/Swifter/HttpRequest.swift
@@ -7,10 +7,13 @@
 import Foundation
 
 public struct HttpRequest {
+    public enum Method: String {
+        case GET, POST, PUT, DELETE
+    }
     
     public let url: String
     public let urlParams: [(String, String)]
-    public let method: String
+    public let method: Method
     public let headers: [String: String]
     public let body: [UInt8]?
     public var address: String?


### PR DESCRIPTION
Re-creating the pull request with updated content, as I accidentally destroyed the old one.

Now, in addition to the old method of routing, you can do the following:

```
server.GET["/path"] = { request in
    // Handle GET request to /path
}

server.POST["/path] = { request in
    // Handle POST request to /path
}

server.PUT["/path"] = { request in
    // Handle PUT request to /path
}

server.DELETE["/path"] = { request in
    // Handle DELETE request to /path
}

server.ANY["/path"] = { request in
    // Handle any of the known HTTP request types for /path
}
```

One other change from this pull request is that HTTP request methods other than GET, POST, PUT, or DELETE result in an error. This can be changed if necessary (or more methods could be added), though I think that it's best for the server itself to catch invalid HTTP method errors.

Currently, `server["/path"]` behaves the same way as it used to (same as `server.ANY["/path"]`), although I recommend changing the behavior of this to either default to GET or to outright remove the old behavior.