### PR TITLE
fix header-elements with more than one ":" per line

### DIFF
--- a/Sources/Swifter/HttpParser.swift
+++ b/Sources/Swifter/HttpParser.swift
@@ -67,7 +67,8 @@ class HttpParser {
                 return requestHeaders
             }
             let headerTokens = headerLine.split(":")
-            if let name = headerTokens.first, value = headerTokens.last where headerTokens.count == 2 {
+            if let name = headerTokens.first where headerTokens.count >= 2 {
+                let value = headerTokens.dropFirst().joinWithSeparator(":")
                 requestHeaders[name.lowercaseString] = value.trim()
             }
         } while true


### PR DESCRIPTION
header tokens are split at ":", but some header fields has sometimes ":" in the value. for example host, refer (for example "referer": "http://localhost:8080/")

this pull request fix this problem and no header data will be lost.