### PR TITLE
fix firefox header websockets connection

### DIFF
--- a/Sources/HttpHandlers+WebSockets.swift
+++ b/Sources/HttpHandlers+WebSockets.swift
@@ -16,7 +16,7 @@ extension HttpHandlers {
             guard r.headers["upgrade"] == "websocket" else {
                 return .BadRequest(.Text("Invalid value of 'Upgrade' header: \(r.headers["upgrade"])"))
             }
-            guard r.headers["connection"] == "Upgrade" else {
+            guard r.headers["connection"] == "Upgrade" || r.headers["connection"] == "keep-alive, Upgrade" else {
                 return .BadRequest(.Text("Invalid value of 'Connection' header: \(r.headers["connection"])"))
             }
             guard let secWebSocketKey = r.headers["sec-websocket-key"] else {


### PR DESCRIPTION
hi
the server not accept connections from firefox - the problem was the header received from firefox:  header was the "connection" : "keep-alive, Upgrade", when in guard condition is "connection" : "Upgrade"