### PR TITLE
Increase the speed of request processing

### DIFF
--- a/Sources/HttpRequest.swift
+++ b/Sources/HttpRequest.swift
@@ -16,8 +16,15 @@ public class HttpRequest {
     public var body: [UInt8] = []
     public var address: String? = ""
     public var params: [String: String] = [:]
+    public var tempFile: String?
     
     public init() {}
+    
+    public func removeTempFileIfExists() throws {
+        if let path = tempFile, try path.exists() {
+            try FileManager.default.removeItem(atPath: path)
+        }
+    }
     
     public func hasTokenForHeader(_ headerName: String, token: String) -> Bool {
         guard let headerValue = headers[headerName] else {

--- a/Sources/HttpRequest.swift
+++ b/Sources/HttpRequest.swift
@@ -24,6 +24,7 @@ public class HttpRequest {
         if let path = tempFile, try path.exists() {
             try FileManager.default.removeItem(atPath: path)
         }
+        tempFile = nil
     }
     
     public func hasTokenForHeader(_ headerName: String, token: String) -> Bool {

--- a/Sources/HttpServer.swift
+++ b/Sources/HttpServer.swift
@@ -40,7 +40,7 @@ public class HttpServer: HttpServerIO {
     }
     
     public var routes: [String] {
-        return router.routes();
+        return router.routes()
     }
     
     public var notFoundHandler: ((HttpRequest) -> HttpResponse)?

--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -122,6 +122,7 @@ public class HttpServerIO {
             let (params, handler) = self.dispatch(request)
             request.params = params
             let response = handler(request)
+            try? request.removeTempFileIfExists()
             var keepConnection = parser.supportsKeepAlive(request.headers)
             do {
                 if self.operating {

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -111,15 +111,17 @@ open class Socket: Hashable, Equatable {
         }
     }
     
-    public typealias SocketReadResult = (count: Int, buffer: [UInt8])
-    
-    open func read(length: Int) throws -> SocketReadResult {
+    open func read(length: Int) throws -> [UInt8] {
         var buffer = [UInt8](repeating: 0, count: length)
         let count = recv(self.socketFileDescriptor as Int32, &buffer, buffer.count, 0)
         if count <= 0 {
             throw SocketError.recvFailed(Errno.description())
         }
-        return (count, buffer)
+        
+        if count < length {
+            buffer.removeSubrange(count..<length)
+        }
+        return buffer
     }
     
     open func read() throws -> UInt8 {

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -111,6 +111,17 @@ open class Socket: Hashable, Equatable {
         }
     }
     
+    public typealias SocketReadResult = (count: Int, buffer: [UInt8])
+    
+    open func read(length: Int) throws -> SocketReadResult {
+        var buffer = [UInt8](repeating: 0, count: length)
+        let count = recv(self.socketFileDescriptor as Int32, &buffer, buffer.count, 0)
+        if count <= 0 {
+            throw SocketError.recvFailed(Errno.description())
+        }
+        return (count, buffer)
+    }
+    
     open func read() throws -> UInt8 {
         var buffer = [UInt8](repeating: 0, count: 1)
         let next = recv(self.socketFileDescriptor as Int32, &buffer, Int(buffer.count), 0)

--- a/Sources/String+File.swift
+++ b/Sources/String+File.swift
@@ -58,17 +58,6 @@ extension String {
             }
         }
         
-        public func write(_ data: [UInt8], count: Int) throws -> Void {
-            if count <= 0 || data.count <= 0 {
-                return
-            }
-            try data.withUnsafeBufferPointer {
-                if fwrite($0.baseAddress, 1, count, self.pointer) != count {
-                    throw FileError.error(errno)
-                }
-            }
-        }
-        
         public static func currentWorkingDirectory() throws -> String {
             guard let path = getcwd(nil, 0) else {
                 throw FileError.error(errno)

--- a/Sources/String+File.swift
+++ b/Sources/String+File.swift
@@ -58,6 +58,17 @@ extension String {
             }
         }
         
+        public func write(_ data: [UInt8], count: Int) throws -> Void {
+            if count <= 0 || data.count <= 0 {
+                return
+            }
+            try data.withUnsafeBufferPointer {
+                if fwrite($0.baseAddress, 1, count, self.pointer) != count {
+                    throw FileError.error(errno)
+                }
+            }
+        }
+        
         public static func currentWorkingDirectory() throws -> String {
             guard let path = getcwd(nil, 0) else {
                 throw FileError.error(errno)


### PR DESCRIPTION
1. Increase the speed of request processing.
    The old `HttpParser.readBody` reads the data very slowly, it is read byte by byte.
    The new `HttpParser.readBody` will try to read 1024 bytes at a time.
2. file upload preprocess, to ensure that the transmission of large files when the memory security.
    I added a new bool property(`filePreprocess`) to `HttpServerIO`
   ```
    /// Bool representation of whether the file upload is preprocessed.
    /// `true` if the file upload requires preprocessing when `content-type` is
    /// `application/octet-stream`. `HttpParser` will create a temp file(`tempFile`) in
    /// `NSTemporaryDirectory()`, and is deleted after the request ends.
    /// Together, `body` will be empty.
    /// `false` otherwise.
    public var filePreprocess: Bool = false
   ```
    On the iPhone to deal with a large file upload, if all write to memory(`HttpRequest.body`), then the program is easy to receive a memory warning and crash.
    So I added the property to make it while reading from the socket, while writing to the temporary file.

    You can see the demo(`/upload/logo`) in `DemoServer.swift`.