### PR TITLE
Add delegate for Web Socket session close event

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -23,11 +23,12 @@ public enum SocketError: Error {
 }
 
 open class Socket: Hashable, Equatable {
-        
+
     let socketFileDescriptor: Int32
+    internal var onShutdown: (() -> Void)?
     private var shutdown = false
 
-    
+
     public init(socketFileDescriptor: Int32) {
         self.socketFileDescriptor = socketFileDescriptor
     }
@@ -44,6 +45,7 @@ open class Socket: Hashable, Equatable {
         }
         shutdown = true
         Socket.close(self.socketFileDescriptor)
+        onShutdown?()
     }
     
     public func port() throws -> in_port_t {

--- a/Sources/WebSockets.swift
+++ b/Sources/WebSockets.swift
@@ -127,6 +127,10 @@ public func websocket(
     }
 }
 
+public protocol WebSocketSessionDelegate: class {
+    func sessionWillClose(_ session: WebSocketSession)
+}
+
 public class WebSocketSession: Hashable, Equatable  {
     
     public enum WsError: Error { case unknownOpCode(String), unMaskedFrame(String), protocolError(String), invalidUTF8(String) }
@@ -142,6 +146,8 @@ public class WebSocketSession: Hashable, Equatable  {
         public var payload = [UInt8]()
     }
 
+    public weak var delegate : WebSocketSessionDelegate?
+
     public let socket: Socket
     
     public init(_ socket: Socket) {
@@ -149,6 +155,7 @@ public class WebSocketSession: Hashable, Equatable  {
     }
     
     deinit {
+        delegate?.sessionWillClose(self)
         writeCloseFrame()
         socket.close()
     }

--- a/Sources/WebSockets.swift
+++ b/Sources/WebSockets.swift
@@ -128,7 +128,7 @@ public func websocket(
 }
 
 public protocol WebSocketSessionDelegate: class {
-    func sessionWillClose(_ session: WebSocketSession)
+    func sessionWasClosed(_ session: WebSocketSession)
 }
 
 public class WebSocketSession: Hashable, Equatable  {
@@ -149,13 +149,15 @@ public class WebSocketSession: Hashable, Equatable  {
     public weak var delegate : WebSocketSessionDelegate?
 
     public let socket: Socket
-    
+
     public init(_ socket: Socket) {
         self.socket = socket
+        socket.onShutdown = { [weak self] in
+            self?.delegate?.sessionWasClosed(self!)
+        }
     }
     
     deinit {
-        delegate?.sessionWillClose(self)
         writeCloseFrame()
         socket.close()
     }


### PR DESCRIPTION
This change allows client code to register a delegate to receive notification when a `WebSocketSession` will close. This should have no effect on sockets which aren't involved in a `WebSocketSession`.

Because of the way that the `WebSocketSession` is retained by a closure, it seemed like `deinit` would be the most reliable place to "notice" that the session is going away. However, I can see arguments for calling the delegate method from another location instead, such as from inside or outside the main `do`/`catch` in the session closure. Let me know if you'd like me to move things around, or if you'd prefer some other solution for this notification.

Thanks!
