### PR TITLE
Add `data` to `HttpResponseBody`

### DIFF
--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -25,6 +25,7 @@ public enum HttpResponseBody {
     case json(AnyObject)
     case html(String)
     case text(String)
+    case data(Data)
     case custom(Any, (Any) throws -> String)
     
     func content() -> (Int, ((HttpResponseBodyWriter) throws -> Void)?) {
@@ -53,6 +54,10 @@ public enum HttpResponseBody {
             case .html(let body):
                 let serialised = "<html><meta charset=\"UTF-8\"><body>\(body)</body></html>"
                 let data = [UInt8](serialised.utf8)
+                return (data.count, {
+                    try $0.write(data)
+                })
+            case .data(let data):
                 return (data.count, {
                     try $0.write(data)
                 })


### PR DESCRIPTION
a very simple response using `Data`, without needing to convert to `String` and `Data` back

useful to mock up a server and when we have a lot of `Data` (files, Moya target)