### PR TITLE
Change NSString cast to avoid linux build failure.

### DIFF
--- a/Sources/MimeTypes.swift
+++ b/Sources/MimeTypes.swift
@@ -136,7 +136,7 @@ extension NSString {
 
 extension String {
     public func mimeType() -> String {
-        return (self as NSString).mimeType()
+        return (NSString(string: self)).mimeType()
     }
 }
 


### PR DESCRIPTION
This change is necessary to be able to compile swifter in linux.