### PR TITLE
Fix bug where server may fail to start

### DIFF
--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -75,6 +75,7 @@ public class HttpServerIO {
         self.state = .starting
         let address = forceIPv4 ? listenAddressIPv4 : listenAddressIPv6
         self.socket = try Socket.tcpSocketForListen(port, forceIPv4, SOMAXCONN, address)
+        self.state = .running
         DispatchQueue.global(qos: priority).async { [weak self] in
             guard let strongSelf = self else { return }
             guard strongSelf.operating else { return }
@@ -93,7 +94,6 @@ public class HttpServerIO {
             }
             strongSelf.stop()
         }
-        self.state = .running
     }
 
     public func stop() {


### PR DESCRIPTION
There is a race condition in `start()` where setting the state to running can happen after the background task starts. The first thing this task does is `guard strongSelf.operating else { return }` which will fail is the state is not running. If the background task starts before the state is set then the background task will exit and the server will not respond.

I've fixed this by setting the state to running before creating the background task. Alternatively we can set the state within the background task.