### PR TITLE
Usage of modern Swift's Encodable for JSON body serialization

### DIFF
--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -27,7 +27,7 @@ public enum HttpResponseBody {
         case json
     }
 
-    static func json<Body: Encodable>(_ body: Body) throws -> HttpResponseBody {
+    static func json(_ body: Encodable) throws -> HttpResponseBody {
         let encoder = JSONEncoder()
 
         let data = try encoder.encode(object)
@@ -128,8 +128,7 @@ public enum HttpResponse {
             }
         case .ok(let body):
             switch body {
-            case .rawData(_, let type): 
-                if case .json = type {
+            case .rawData(_, let type) where type == .json:
                     headers["Content-Type"] = "application/json"
                 }
             case .html: 

--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -22,7 +22,7 @@ public protocol HttpResponseBodyWriter {
 
 public enum HttpResponseBody {
     
-    enum RawDataType {
+    public enum RawDataType {
         case any
         case json
     }
@@ -58,7 +58,7 @@ public enum HttpResponseBody {
                 return (data.count, {
                     try $0.write(data)
                 })
-            case .data(let data):
+            case .rawData(let data, _):
                 return (data.count, {
                     try $0.write(data)
                 })
@@ -128,7 +128,7 @@ public enum HttpResponse {
             }
         case .ok(let body):
             switch body {
-            case .data(_, type): 
+            case .rawData(_, let type): 
                 if case .json = type {
                     headers["Content-Type"] = "application/json"
                 }


### PR DESCRIPTION
The stable branch didn't feature any support for proper encoding on Linux so I decided maybe this completely backwards compatible tweak would resolve the issue.
Resolves #324 .