### PR TITLE
Add .movedTemporarily case (HTTP 307) to HttpResponse

### DIFF
--- a/Sources/DemoServer.swift
+++ b/Sources/DemoServer.swift
@@ -154,8 +154,12 @@ public func demoServer(_ publicDir: String) -> HttpServer {
         return HttpResponse.raw(200, "OK", ["XXX-Custom-Header": "value"], { try $0.write([UInt8]("test".utf8)) })
     }
     
-    server["/redirect"] = { r in
+    server["/redirect/permanently"] = { r in
         return .movedPermanently("http://www.google.com")
+    }
+    
+    server["/redirect/temporarily"] = { r in
+        return .movedTemporarily("http://www.google.com")
     }
 
     server["/long"] = { r in

--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -82,6 +82,7 @@ public enum HttpResponse {
     case switchProtocols([String: String], (Socket) -> Void)
     case ok(HttpResponseBody), created, accepted
     case movedPermanently(String)
+    case movedTemporarily(String)
     case badRequest(HttpResponseBody?), unauthorized, forbidden, notFound
     case internalServerError
     case raw(Int, String, [String:String]?, ((HttpResponseBodyWriter) throws -> Void)? )
@@ -93,6 +94,7 @@ public enum HttpResponse {
         case .created                 : return 201
         case .accepted                : return 202
         case .movedPermanently        : return 301
+        case .movedTemporarily        : return 307
         case .badRequest(_)           : return 400
         case .unauthorized            : return 401
         case .forbidden               : return 403
@@ -109,6 +111,7 @@ public enum HttpResponse {
         case .created                  : return "Created"
         case .accepted                 : return "Accepted"
         case .movedPermanently         : return "Moved Permanently"
+        case .movedTemporarily         : return "Moved Temporarily"
         case .badRequest(_)            : return "Bad Request"
         case .unauthorized             : return "Unauthorized"
         case .forbidden                : return "Forbidden"
@@ -132,6 +135,8 @@ public enum HttpResponse {
             default:break
             }
         case .movedPermanently(let location):
+            headers["Location"] = location
+        case .movedTemporarily(let location):
             headers["Location"] = location
         case .raw(_, _, let rawHeaders, _):
             if let rawHeaders = rawHeaders {


### PR DESCRIPTION
Hi, I'm currently working on prototype based on Swifter and I needed a temporary redirect which I've now commited to my fork. 

Do you think this could be useful to integrate in the main repo?

I've used HTTP 307 as I don't need to change the HTTP method on the redirect but if you think that it is a common scenario I'd be happy to change it to 302 and resubmit the PR.