### PR TITLE
Fix the HttpRouter to handle overlapping of the routes

### DIFF
--- a/Sources/HttpRouter.swift
+++ b/Sources/HttpRouter.swift
@@ -81,47 +81,76 @@ open class HttpRouter {
     }
     
     private func findHandler(_ node: inout Node, params: inout [String: String], generator: inout IndexingIterator<[String]>) -> ((HttpRequest) -> HttpResponse)? {
-        guard let pathToken = generator.next()?.removingPercentEncoding else {
+        
+        var matchedRoutes = [Node]()
+        findHandler(&node, params: &params, generator: &generator, matchedNodes: &matchedRoutes, index: 0, count: generator.reversed().count)
+        return matchedRoutes.first?.handler
+    }
+    
+    /// Find the handlers for a specified route
+    ///
+    /// - Parameters:
+    ///   - node: The root node of the tree representing all the routes
+    ///   - params: The parameters of the match
+    ///   - generator: The IndexingIterator to iterate through the pattern to match
+    ///   - matchedNodes: An array with the nodes matching the route
+    ///   - index: The index of current position in the generator
+    ///   - count: The number of elements if the route to match
+    private func findHandler(_ node: inout Node, params: inout [String: String], generator: inout IndexingIterator<[String]>, matchedNodes: inout [Node], index: Int, count: Int) {
+    
+        if let pathToken = generator.next()?.removingPercentEncoding {
+            
+            var currentIndex = index + 1
+            let variableNodes = node.nodes.filter { $0.0.first == ":" }
+            if let variableNode = variableNodes.first {
+                if variableNode.1.nodes.count == 0 {
+                    // if it's the last element of the pattern and it's a variable, stop the search and
+                    // append a tail as a value for the variable.
+                    let tail = generator.joined(separator: "/")
+                    if tail.count > 0 {
+                        params[variableNode.0] = pathToken + "/" + tail
+                    } else {
+                        params[variableNode.0] = pathToken
+                    }
+                    
+                    matchedNodes.append(variableNode.value)
+                    return
+                }
+                params[variableNode.0] = pathToken
+                findHandler(&node.nodes[variableNode.0]!, params: &params, generator: &generator, matchedNodes: &matchedNodes, index: currentIndex, count: count)
+            }
+            
+            if var node = node.nodes[pathToken] {
+                findHandler(&node, params: &params, generator: &generator, matchedNodes: &matchedNodes, index: currentIndex, count: count)
+            }
+            
+            if var node = node.nodes["*"] {
+                findHandler(&node, params: &params, generator: &generator, matchedNodes: &matchedNodes, index: currentIndex, count: count)
+            }
+            
+            if let startStarNode = node.nodes["**"] {
+                let startStarNodeKeys = startStarNode.nodes.keys
+                while let pathToken = generator.next() {
+                    currentIndex += 1
+                    if startStarNodeKeys.contains(pathToken) {
+                        findHandler(&startStarNode.nodes[pathToken]!, params: &params, generator: &generator, matchedNodes: &matchedNodes, index: currentIndex, count: count)
+                    }
+                }
+            }
+        } else if let variableNode = node.nodes.filter({ $0.0.first == ":" }).first {
             // if it's the last element of the requested URL, check if there is a pattern with variable tail.
-            if let variableNode = node.nodes.filter({ $0.0.first == ":" }).first {
-                if variableNode.value.nodes.isEmpty {
-                    params[variableNode.0] = ""
-                    return variableNode.value.handler
-                }
-            }
-            return node.handler
-        }
-        let variableNodes = node.nodes.filter { $0.0.first == ":" }
-        if let variableNode = variableNodes.first {
-            if variableNode.1.nodes.count == 0 {
-                // if it's the last element of the pattern and it's a variable, stop the search and
-                // append a tail as a value for the variable.
-                let tail = generator.joined(separator: "/")
-                if tail.count > 0 {
-                    params[variableNode.0] = pathToken + "/" + tail
-                } else {
-                    params[variableNode.0] = pathToken
-                }
-                return variableNode.1.handler
-            }
-            params[variableNode.0] = pathToken
-            return findHandler(&node.nodes[variableNode.0]!, params: &params, generator: &generator)
-        }
-        if var node = node.nodes[pathToken] {
-            return findHandler(&node, params: &params, generator: &generator)
-        }
-        if var node = node.nodes["*"] {
-            return findHandler(&node, params: &params, generator: &generator)
-        }
-        if let startStarNode = node.nodes["**"] {
-            let startStarNodeKeys = startStarNode.nodes.keys
-            while let pathToken = generator.next() {
-                if startStarNodeKeys.contains(pathToken) {
-                    return findHandler(&startStarNode.nodes[pathToken]!, params: &params, generator: &generator)
-                }
+            if variableNode.value.nodes.isEmpty {
+                params[variableNode.0] = ""
+                matchedNodes.append(variableNode.value)
+                return
             }
         }
-        return nil
+        
+        // if it's the last element and the path to match is done then it's a pattern matching
+        if node.nodes.isEmpty && index == count {
+            matchedNodes.append(node)
+            return
+        }
     }
     
     private func stripQuery(_ path: String) -> String {

--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		7AE893EA1C05127900A29F63 /* SwifteriOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AE893E91C05127900A29F63 /* SwifteriOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AE893FE1C0512C400A29F63 /* SwifterMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AE893FD1C0512C400A29F63 /* SwifterMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AE8940D1C05151100A29F63 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7AE8940C1C05151100A29F63 /* Launch Screen.storyboard */; };
+		7B11AD4B21C9A8A6002F8820 /* SwifterTestsHttpRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCB8C5F1D97B8CC008B9712 /* SwifterTestsHttpRouter.swift */; };
 		7B74CFA82163C40F001BE07B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAB80C1BE2A1D400C8A977 /* AppDelegate.swift */; };
 		7C377E181D964B96009C6148 /* String+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C377E161D964B6A009C6148 /* String+File.swift */; };
 		7C377E191D964B9F009C6148 /* String+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C377E161D964B6A009C6148 /* String+File.swift */; };
@@ -780,6 +781,7 @@
 				0858E7F41D68BB2600491CD1 /* IOSafetyTests.swift in Sources */,
 				7C4785E91C71D15600A9FE73 /* SwifterTestsWebSocketSession.swift in Sources */,
 				7CCD87721C660B250068099B /* SwifterTestsStringExtensions.swift in Sources */,
+				7B11AD4B21C9A8A6002F8820 /* SwifterTestsHttpRouter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR should fix #355 and can be resumed in the following steps:

* Fix the `HttpRouter` to handle overlapping between routes with wildcard correctly.
* Include the `SwifterTestHttpRouter` in the `SwifteriOSTests`.
* Add a unit tests for overlapped routes.

The current `findHandler(_:, ..)` function was taking only one path once a match was found and sometimes incorrectly, let's see the two routes proposed in the issue:

- `a/b`
- `a/:id/c`

If we see the following tree generated by the two routes above it should look like the following:

```bash
                                   GET
                                    |
                                    a
                                  /   \
                                :id    b
                               /
                              c

```

The previous `findHandler(_:, ..)` algorithm was traversing the path recursively and returning if a match was found but the way it was implemented makes really hard to take advantage of the recursive search to continue searching in case of went through a path incorrectly. 

In the refactored algorithm I didn't return only a match, nevertheless, all the possible matches in the Tree kept in an array and handling the incorrect path without return anything directly.

There are several updates to the previous algorithms in terms of refactoring but two are very important:

1. The necessity of keeping the current index inside the `generator`.
2. Handle the case of when the `generator` doesn't have more nodes and the current node neither and that means it's a match in the tree.

Happy to discuss more or any doubt in the refactoring. Happy review! 