### PR TITLE
Set to NO Always embed Swift Standard Libraries in tvOS

### DIFF
--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -852,6 +852,7 @@
 		269B479F1D3AAAE20042D137 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -879,6 +880,7 @@
 		269B47A01D3AAAE20042D137 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";


### PR DESCRIPTION
This PR overrides #338. It was easier just to create a new PR with the changes suggested in the previous PR that rebase and clean the old one.

* Set to `NO` the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` in the tvOS target to avoid App Store checks due to Frameworks directory.