### PR TITLE
Faster reading of request body and headers

### DIFF
--- a/Sources/HttpParser.swift
+++ b/Sources/HttpParser.swift
@@ -64,11 +64,9 @@ public class HttpParser {
                 return c + [(name, value)]
         }
     }
-    
+
     private func readBody(_ socket: Socket, size: Int) throws -> [UInt8] {
-        var body = [UInt8]()
-        for _ in 0..<size { body.append(try socket.read()) }
-        return body
+        return try socket.read(length: size)
     }
     
     private func readHeaders(_ socket: Socket) throws -> [String: String] {


### PR DESCRIPTION
Based on this comment that I agree with from @macarse https://github.com/httpswift/swifter/pull/253#pullrequestreview-140463925

The request reading is very inefficient by reading 1 byte at a time. In theory the OS might be buffering much more data because it knows how inefficient that is, but we should still see significant speed improvements by reading large amounts of data at once. This is due to the large amount of buffer allocation thrash.

The new approach is to read up to 1KB of request data in one shot. Now, a response with 4,500 bytes would see 4x 1024B reads, and then a 404 byte read to finish up. Before this PR, it would be 4,500 individual reads.

I also changed the unit test mock Socket to use actual OS sockets. This way we can test the read read flows!