### PR TITLE
Add a CHANGELOG.md to keep track of changes in the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file. Changes not
 
 # [Unreleased]
 
+## Added
+- A new `CHANGELOG.md` to keep track of changes in the project. ([#385](https://github.com/httpswift/swifter/pull/385)) by [@Vkt0r](https://github.com/Vkt0r)
+
 ## Fixed
 - An issue in the `HttpRouter` causing issues to handle routes with overlapping in the tail. ([#379](https://github.com/httpswift/swifter/pull/359), [#382](https://github.com/httpswift/swifter/pull/382)) by [@Vkt0r](https://github.com/Vkt0r)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+All notable changes to this project will be documented in this file. Changes notes typically follow this pattern:
+
+> **Fixed**
+> * Something was fixed. (#pr-number) by @pr-author
+> 
+> **Changed**
+> * Something was changed. (#pr-number) by @pr-author
+> 
+> **Added**
+> * Something was added. (#pr-number) by @pr-author
+> 
+> **Removed**
+> * Something was removed. (#pr-number) by @pr-author
+> 
+> **Deprecated**
+> * Something was deprecated. (#pr-number) by @pr-author
+
+# [Unreleased]
+
+## Fixed
+- An issue in the `HttpRouter` causing issues to handle routes with overlapping in the tail. ([#379](https://github.com/httpswift/swifter/pull/359), [#382](https://github.com/httpswift/swifter/pull/382)) by [@Vkt0r](https://github.com/Vkt0r)
+
+# [1.4.6] 
+## Added
+ -  The `.movedTemporarily` case (HTTP 307) to possibles HTTP responses. ([#352](https://github.com/httpswift/swifter/pull/352)) by [@csch](https://github.com/csch)
+ - An example to the `README` for `"How to load HTML by string?"`. ([#352](https://github.com/httpswift/swifter/pull/352)) by [@IvanovDeveloper]( https://github.com/IvanovDeveloper)
+ - CircleCI for Continous Integration in the project. ([#364](https://github.com/httpswift/swifter/pull/364)) by [@Vkt0r](https://github.com/Vkt0r)
+ - Support for the Swift 5. ([#370](https://github.com/httpswift/swifter/pull/370)) by [@alanzeino](https://github.com/alanzeino)
+
+## Changed
+- The syntax to support Swift 3 and Swift 4. ([#347](https://github.com/httpswift/swifter/pull/347)) by [@fandyfyf](https://github.com/fandyfyf)
+- Set to `NO` the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` in the **tvOS** target to avoid App Store checks due to the _Frameworks_ directory. ([#361](https://github.com/httpswift/swifter/pull/361)) by [@Vkt0r](https://github.com/Vkt0r)
+- The process of reading of request body and headers. ([#362](https://github.com/httpswift/swifter/pull/362)) by [@adamkaplan](https://github.com/adamkaplan)
+
+## Fixed
+- An issue in the `HttpRouter` causing issues to handle routes with overlapping. ([#359](https://github.com/httpswift/swifter/pull/359)) by [@Vkt0r](https://github.com/Vkt0r)
+
+
+[Unreleased]: https://github.com/httpswift/swifter/compare/1.4.6...HEAD
+[1.4.6]: https://github.com/httpswift/swifter/compare/1.4.5...1.4.6


### PR DESCRIPTION
With a `CHANGELOG.md` we can keep track of changes in each PR and make the release notes more readable for everyone looking for changes between versions. I took the main concept from https://keepachangelog.com/en/1.0.0/. 

The expected behavior should add a new entry to the `CHANGELOG.md` in each PR explaining what it brings to the project. I created the version 1.4.6 entry in the current `CHANGELOG.md` as an example. Open to any suggestions and improvements in the words, etc. 