### PR TITLE
`WebsocketSession.readFrame()` should batch read payload bytes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file. Changes not
 ## Fixed
 - An issue in the `HttpRouter` causing issues to handle routes with overlapping in the tail. ([#379](https://github.com/httpswift/swifter/pull/359), [#382](https://github.com/httpswift/swifter/pull/382)) by [@Vkt0r](https://github.com/Vkt0r)
 
+## Changed
+- Performance: Batch reads of websocket payloads rather than reading byte-by-byte. ([#387](https://github.com/httpswift/swifter/pull/387)) by [@lynaghk](https://github.com/lynaghk)
+
+
 # [1.4.6] 
 ## Added
  -  The `.movedTemporarily` case (HTTP 307) to possibles HTTP responses. ([#352](https://github.com/httpswift/swifter/pull/352)) by [@csch](https://github.com/csch)

--- a/Sources/WebSockets.swift
+++ b/Sources/WebSockets.swift
@@ -276,9 +276,12 @@ public class WebSocketSession: Hashable, Equatable  {
             let b7 = UInt64(try socket.read())
             len = UInt64(littleEndian: b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7)
         }
+
         let mask = [try socket.read(), try socket.read(), try socket.read(), try socket.read()]
+        //Read payload all at once, then apply mask (calling `socket.read` byte-by-byte is super slow).
+        frm.payload = try socket.read(length: Int(len))
         for i in 0..<len {
-            frm.payload.append(try socket.read() ^ mask[Int(i % 4)])
+            frm.payload[Int(i)] ^= mask[Int(i % 4)]
         }
         return frm
     }


### PR DESCRIPTION
This is much faster than calling `socket.read()` to read byte-by-byte.
I believe this is the same issue raised here: https://github.com/httpswift/swifter/issues/314