### PR TITLE
Allow Any Type for JSON Response

### DIFF
--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -22,7 +22,7 @@ public protocol HttpResponseBodyWriter {
 
 public enum HttpResponseBody {
     
-    case json(AnyObject)
+    case json(Any)
     case html(String)
     case text(String)
     case data(Data)


### PR DESCRIPTION
Using `AnyObject` type prohibits the use of Swift collections (Array, Dictionary). Instead of casting them to Objective C equivalent (NSArray, NSDictionary), probably best to support the `Any` type.

I made the changes on Github directly. I'll test more locally and perhaps add tests if you require so.