### PR TITLE
Fix the Swifter.podspec path to the source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file. Changes not
 
 ## Changed
 - Performance: Batch reads of websocket payloads rather than reading byte-by-byte. ([#387](https://github.com/httpswift/swifter/pull/387)) by [@lynaghk](https://github.com/lynaghk)
-
+- Podspec source_files updated to match source file directory changes. ([#400](https://github.com/httpswift/swifter/pull/400)) by [@welsonpan](https://github.com/welsonpan)
 
 # [1.4.6] 
 ## Added

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
   s.source                = { :git => "https://github.com/httpswift/swifter.git", :tag => "1.4.6" }
-  s.source_files          = 'Sources/*.{swift}'
+  s.source_files          = 'XCode/Sources/*.{swift}'
 
 end


### PR DESCRIPTION
After forking the repository, pointing my `Podfile` at the fork, and running `pod install`, I found that my `Pods/Swifter` directory was empty.

Since the source files now exist in `XCode/Sources/`, the podspec should be updated.