### PR TITLE
Add header item "Content-Length“

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -36,8 +36,20 @@ public func shareFilesFromDirectory(_ directoryPath: String, defaults: [String] 
         }
         if let file = try? (directoryPath + String.pathSeparator + fileRelativePath.value).openForReading() {
             let mimeType = fileRelativePath.value.mimeType();
-            
-            return .raw(200, "OK", ["Content-Type": mimeType], { writer in
+
+            var responseHeader: [String: String]
+
+            do {
+                let filePath = directoryPath + String.pathSeparator + fileRelativePath.value
+                let attr = try FileManager.default.attributesOfItem(atPath: filePath)
+                let fileSize = attr[FileAttributeKey.size] as! UInt64
+
+                responseHeader = ["Content-Type": mimeType, "Content-Length": String(fileSize)]
+            } catch {
+                responseHeader = ["Content-Type": mimeType]
+            }
+
+            return .raw(200, "OK", responseHeader, { writer in
                 try? writer.write(file)
                 file.close()
             })


### PR DESCRIPTION
Add header item "Content-Length" to response when shareFilesFromDirectory is used to share files.

This PR is related to this #380  .