### PR TITLE
Use Foundation API for Base64 Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. Changes not
 ## Changed
 - Performance: Batch reads of websocket payloads rather than reading byte-by-byte. ([#387](https://github.com/httpswift/swifter/pull/387)) by [@lynaghk](https://github.com/lynaghk)
 - Podspec source_files updated to match source file directory changes. ([#400](https://github.com/httpswift/swifter/pull/400)) by [@welsonpan](https://github.com/welsonpan)
+- Refactor: Use Foundation API for Base64 encoding. ([#403](https://github.com/httpswift/swifter/pull/403)) by [@mazyod](https://github.com/mazyod)
 
 # [1.4.6] 
 ## Added

--- a/XCode/Sources/String+BASE64.swift
+++ b/XCode/Sources/String+BASE64.swift
@@ -9,37 +9,7 @@ import Foundation
 
 extension String {
     
-    private static let CODES = [UInt8]("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".utf8)
-    
-    public static func toBase64(_ data: [UInt8]) -> String? {
-        
-        // Based on: https://en.wikipedia.org/wiki/Base64#Sample_Implementation_in_Java
-        
-        var result = [UInt8]()
-        var tmp: UInt8
-        for index in stride(from: 0, to: data.count, by: 3) {
-            let byte = data[index]
-            tmp = (byte & 0xFC) >> 2
-            result.append(CODES[Int(tmp)])
-            tmp = (byte & 0x03) << 4
-            if index + 1 < data.count {
-                tmp |= (data[index + 1] & 0xF0) >> 4
-                result.append(CODES[Int(tmp)])
-                tmp = (data[index + 1] & 0x0F) << 2
-                if index + 2 < data.count {
-                    tmp |= (data[index + 2] & 0xC0) >> 6
-                    result.append(CODES[Int(tmp)])
-                    tmp = data[index + 2] & 0x3F
-                    result.append(CODES[Int(tmp)])
-                } else {
-                    result.append(CODES[Int(tmp)])
-                    result.append(contentsOf: [UInt8]("=".utf8))
-                }
-            } else {
-                result.append(CODES[Int(tmp)])
-                result.append(contentsOf: [UInt8]("==".utf8))
-            }
-        }
-        return String(bytes: result, encoding: .utf8)
+    public static func toBase64(_ data: [UInt8]) -> String {
+        return Data(data).base64EncodedString()
     }
 }

--- a/XCode/Sources/WebSockets.swift
+++ b/XCode/Sources/WebSockets.swift
@@ -139,9 +139,7 @@ public func websocket(
             
             disconnected?(session)
         }
-        guard let secWebSocketAccept = String.toBase64((secWebSocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").sha1()) else {
-            return HttpResponse.internalServerError
-        }
+        let secWebSocketAccept = String.toBase64((secWebSocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").sha1())
         let headers = ["Upgrade": "WebSocket", "Connection": "Upgrade", "Sec-WebSocket-Accept": secWebSocketAccept]
         return HttpResponse.switchProtocols(headers, protocolSessionClosure)
     }


### PR DESCRIPTION

Note, I didn't see the need to update the changelog, as this is extremely minor and should be transparent to the users. If you'd like an entry anyway, I can add that as well.

Fixes #394.