### PR TITLE
Drop the macOS 10.9 support in the Swifter.podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file. Changes not
 - Refactor: Use `URLComponents` for `HttpRequest` path and query parameters parsing [#404](https://github.com/httpswift/swifter/pull/404)) by [@mazyod](https://github.com/mazyod)
 
 ## Removed
-- Dropped macOS 10.9 support [#404](https://github.com/httpswift/swifter/pull/404)) by [@mazyod](https://github.com/mazyod)
+- Dropped macOS 10.9 support [#404](https://github.com/httpswift/swifter/pull/404)), [#408](https://github.com/httpswift/swifter/pull/408)) by [@mazyod](https://github.com/mazyod), [@Vkt0r](https://github.com/Vkt0r)
 
 # [1.4.6] 
 ## Added

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license               = { :type => 'Copyright', :file => 'LICENSE' }
   s.author                = { "Damian Kołakowski" => "kolakowski.damian@gmail.com" }
   s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.9"
+  s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
   s.source                = { :git => "https://github.com/httpswift/swifter.git", :tag => "1.4.6" }
   s.source_files          = 'XCode/Sources/*.{swift}'


### PR DESCRIPTION
This is really small PR and it would just take care of drop the macOS 10.9 support in #404 the `Swifter.podspec` causing when the `stable` branch is pulled a compilation error is thrown in the `Pods.xcodeproj `.