### PR TITLE
Added scopes, make headers and status code public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. Changes not
 ## Added
 - A new `CHANGELOG.md` to keep track of changes in the project. ([#385](https://github.com/httpswift/swifter/pull/385)) by [@Vkt0r](https://github.com/Vkt0r)
 - Added [Danger](https://danger.systems/ruby/) and Swiftlint to the project. ([#398](https://github.com/httpswift/swifter/pull/398)) by [@Vkt0r](https://github.com/Vkt0r)
+- Added the following to `Scopes`: `manifest`, `ontouchstart`, `dataText`. ([#410](https://github.com/httpswift/swifter/pull/410)) by [@apocolipse](https://github.com/apocolipse)
 
 ## Fixed
 - An issue causing a crash regarding a thread race condition. ([#399](https://github.com/httpswift/swifter/pull/399)) by [@Vkt0r](https://github.com/Vkt0r)
@@ -35,6 +36,8 @@ All notable changes to this project will be documented in this file. Changes not
 - Podspec source_files updated to match source file directory changes. ([#400](https://github.com/httpswift/swifter/pull/400)) by [@welsonpan](https://github.com/welsonpan)
 - Refactor: Use Foundation API for Base64 encoding. ([#403](https://github.com/httpswift/swifter/pull/403)) by [@mazyod](https://github.com/mazyod)
 - Refactor: Use `URLComponents` for `HttpRequest` path and query parameters parsing [#404](https://github.com/httpswift/swifter/pull/404)) by [@mazyod](https://github.com/mazyod)
+- `HttpResponse` functions `statusCode()` and `reasonPhrase` changed to computed variables instead of functions, and made public (No impact on existing usage as it was previously internal). ([#410](https://github.com/httpswift/swifter/pull/410)) by [@apocolipse](https://github.com/apocolipse)
+
 
 ## Removed
 - Dropped macOS 10.9 support [#404](https://github.com/httpswift/swifter/pull/404)) by [@mazyod](https://github.com/mazyod)

--- a/XCode/Sources/HttpResponse.swift
+++ b/XCode/Sources/HttpResponse.swift
@@ -21,13 +21,13 @@ public protocol HttpResponseBodyWriter {
 }
 
 public enum HttpResponseBody {
-    
+
     case json(AnyObject)
     case html(String)
     case text(String)
     case data(Data)
     case custom(Any, (Any) throws -> String)
-    
+
     func content() -> (Int, ((HttpResponseBodyWriter) throws -> Void)?) {
         do {
             switch self {
@@ -79,7 +79,7 @@ public enum HttpResponseBody {
 
 // swiftlint:disable cyclomatic_complexity
 public enum HttpResponse {
-    
+
     case switchProtocols([String: String], (Socket) -> Void)
     case ok(HttpResponseBody), created, accepted
     case movedPermanently(String)
@@ -88,7 +88,7 @@ public enum HttpResponse {
     case internalServerError
     case raw(Int, String, [String:String]?, ((HttpResponseBodyWriter) throws -> Void)? )
 
-    func statusCode() -> Int {
+    public var statusCode: Int {
         switch self {
         case .switchProtocols         : return 101
         case .ok                      : return 200
@@ -101,11 +101,11 @@ public enum HttpResponse {
         case .forbidden               : return 403
         case .notFound                : return 404
         case .internalServerError     : return 500
-        case .raw(let code, _, _, _) : return code
+        case .raw(let code, _, _, _)  : return code
         }
     }
-    
-    func reasonPhrase() -> String {
+
+    public var reasonPhrase: String {
         switch self {
         case .switchProtocols          : return "Switching Protocols"
         case .ok                       : return "OK"
@@ -121,8 +121,8 @@ public enum HttpResponse {
         case .raw(_, let phrase, _, _) : return phrase
         }
     }
-    
-    func headers() -> [String: String] {
+
+    public func headers() -> [String: String] {
         var headers = ["Server": "Swifter \(HttpServer.VERSION)"]
         switch self {
         case .switchProtocols(let switchHeaders, _):
@@ -149,7 +149,7 @@ public enum HttpResponse {
         }
         return headers
     }
-    
+
     func content() -> (length: Int, write: ((HttpResponseBodyWriter) throws -> Void)?) {
         switch self {
         case .ok(let body)             : return body.content()
@@ -158,7 +158,7 @@ public enum HttpResponse {
         default                        : return (-1, nil)
         }
     }
-    
+
     func socketSession() -> ((Socket) -> Void)? {
         switch self {
         case .switchProtocols(_, let handler) : return handler
@@ -171,7 +171,7 @@ public enum HttpResponse {
     Makes it possible to compare handler responses with '==', but
 	ignores any associated values. This should generally be what
 	you want. E.g.:
-	
+
     let resp = handler(updatedRequest)
         if resp == .NotFound {
         print("Client requested not found: \(request.url)")
@@ -179,5 +179,5 @@ public enum HttpResponse {
 */
 
 func == (inLeft: HttpResponse, inRight: HttpResponse) -> Bool {
-    return inLeft.statusCode() == inRight.statusCode()
+    return inLeft.statusCode == inRight.statusCode
 }

--- a/XCode/Sources/HttpServerIO.swift
+++ b/XCode/Sources/HttpServerIO.swift
@@ -175,7 +175,7 @@ public class HttpServerIO {
         
         var responseHeader = String()
 
-        responseHeader.append("HTTP/1.1 \(response.statusCode()) \(response.reasonPhrase())\r\n")
+        responseHeader.append("HTTP/1.1 \(response.statusCode) \(response.reasonPhrase)\r\n")
 
         let content = response.content()
 

--- a/XCode/Sources/Scopes.swift
+++ b/XCode/Sources/Scopes.swift
@@ -60,6 +60,7 @@ public var media: String?
 public var title: String?
 public var scope: String?
 public var classs: String?
+public var manifest: String?
 public var value: String?
 public var clear: String?
 public var start: String?
@@ -85,6 +86,7 @@ public var prompt: String?
 public var onfocus: String?
 public var enctype: String?
 public var onclick: String?
+public var ontouchstart: String?
 public var onkeyup: String?
 public var profile: String?
 public var version: String?
@@ -131,6 +133,7 @@ public var onkeypress: String?
 public var ondblclick: String?
 public var onmouseout: String?
 public var httpEquiv: String?
+public var dataText: String?
 public var background: String?
 public var onmousemove: String?
 public var onmouseover: String?
@@ -334,9 +337,9 @@ var scopesBuffer = [UInt64: String]()
 
 // swiftlint:disable cyclomatic_complexity function_body_length
 private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closure: Closure) {
-    
+
     // Push the attributes.
-    
+
     let stackid = idd
     let stackdir = dir
     let stackrel = rel
@@ -377,6 +380,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     let stacktitle = title
     let stackscope = scope
     let stackclass = classs
+    let stackmanifest = manifest
     let stackvalue = value
     let stackclear = clear
     let stackstart = start
@@ -402,6 +406,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     let stackonfocus = onfocus
     let stackenctype = enctype
     let stackonclick = onclick
+    let stackontouchstart = ontouchstart
     let stackonkeyup = onkeyup
     let stackprofile = profile
     let stackversion = version
@@ -447,6 +452,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     let stackondblclick = ondblclick
     let stackonmouseout = onmouseout
     let stackhttpEquiv = httpEquiv
+    let stackdataText = dataText
     let stackbackground = background
     let stackonmousemove = onmousemove
     let stackonmouseover = onmouseover
@@ -459,9 +465,9 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     let stackmarginheight = marginheight
     let stackacceptCharset = acceptCharset
     let stackinner = inner
-    
+
     // Reset the values before a nested scope evalutation.
-    
+
     idd = nil
     dir = nil
     rel = nil
@@ -502,6 +508,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     title = nil
     scope = nil
     classs = nil
+    manifest = nil
     value = nil
     clear = nil
     start = nil
@@ -527,6 +534,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     onfocus = nil
     enctype = nil
     onclick = nil
+    ontouchstart = nil
     onkeyup = nil
     profile = nil
     version = nil
@@ -572,6 +580,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     ondblclick = nil
     onmouseout = nil
     httpEquiv = nil
+    dataText = nil
     background = nil
     onmousemove = nil
     onmouseover = nil
@@ -584,25 +593,25 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     marginheight = nil
     acceptCharset = nil
     inner = nil
-    
+
     scopesBuffer[Process.tid] = (scopesBuffer[Process.tid] ?? "") + "<" + node
-    
+
     // Save the current output before the nested scope evalutation.
-    
+
     var output = scopesBuffer[Process.tid] ?? ""
-    
+
     // Clear the output buffer for the evalutation.
-    
+
     scopesBuffer[Process.tid] = ""
-    
+
     // Evaluate the nested scope.
-    
+
     closure()
-    
+
     // Render attributes set by the evalutation.
-    
+
     var mergedAttributes = [String: String?]()
-    
+
     if let idd = idd { mergedAttributes["id"] = idd }
     if let dir = dir { mergedAttributes["dir"] = dir }
     if let rel = rel { mergedAttributes["rel"] = rel }
@@ -643,6 +652,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     if let title = title { mergedAttributes["title"] = title }
     if let scope = scope { mergedAttributes["scope"] = scope }
     if let classs = classs { mergedAttributes["class"] = classs }
+    if let manifest = manifest { mergedAttributes["manifest"] = manifest }
     if let value = value { mergedAttributes["value"] = value }
     if let clear = clear { mergedAttributes["clear"] = clear }
     if let start = start { mergedAttributes["start"] = start }
@@ -668,6 +678,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     if let onfocus = onfocus { mergedAttributes["onfocus"] = onfocus }
     if let enctype = enctype { mergedAttributes["enctype"] = enctype }
     if let onclick = onclick { mergedAttributes["onclick"] = onclick }
+    if let ontouchstart = ontouchstart { mergedAttributes["ontouchstart"] = ontouchstart }
     if let onkeyup = onkeyup { mergedAttributes["onkeyup"] = onkeyup }
     if let profile = profile { mergedAttributes["profile"] = profile }
     if let version = version { mergedAttributes["version"] = version }
@@ -713,6 +724,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     if let ondblclick = ondblclick { mergedAttributes["ondblclick"] = ondblclick }
     if let onmouseout = onmouseout { mergedAttributes["onmouseout"] = onmouseout }
     if let httpEquiv = httpEquiv { mergedAttributes["http-equiv"] = httpEquiv }
+    if let dataText = dataText { mergedAttributes["data-text"] = dataText }
     if let background = background { mergedAttributes["background"] = background }
     if let onmousemove = onmousemove { mergedAttributes["onmousemove"] = onmousemove }
     if let onmouseover = onmouseover { mergedAttributes["onmouseover"] = onmouseover }
@@ -724,11 +736,11 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     if let placeholder = placeholder { mergedAttributes["placeholder"] = placeholder }
     if let marginheight = marginheight { mergedAttributes["marginheight"] = marginheight }
     if let acceptCharset = acceptCharset { mergedAttributes["accept-charset"] = acceptCharset }
-    
+
     for item in attrs.enumerated() {
         mergedAttributes.updateValue(item.element.1, forKey: item.element.0)
     }
-    
+
     output += mergedAttributes.reduce("") { result, item in
         if let value = item.value {
             return result + " \(item.key)=\"\(value)\""
@@ -736,16 +748,16 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
             return result
         }
     }
-    
+
     if let inner = inner {
         scopesBuffer[Process.tid] = output + ">" + (inner) + "</" + node + ">"
     } else {
         let current = scopesBuffer[Process.tid]  ?? ""
         scopesBuffer[Process.tid] = output + ">" + current + "</" + node + ">"
     }
-    
+
     // Pop the attributes.
-    
+
     idd = stackid
     dir = stackdir
     rel = stackrel
@@ -786,6 +798,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     title = stacktitle
     scope = stackscope
     classs = stackclass
+    manifest = stackmanifest
     value = stackvalue
     clear = stackclear
     start = stackstart
@@ -811,6 +824,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     onfocus = stackonfocus
     enctype = stackenctype
     onclick = stackonclick
+    ontouchstart = stackontouchstart
     onkeyup = stackonkeyup
     profile = stackprofile
     version = stackversion
@@ -856,6 +870,7 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     ondblclick = stackondblclick
     onmouseout = stackonmouseout
     httpEquiv = stackhttpEquiv
+    dataText = stackdataText
     background = stackbackground
     onmousemove = stackonmousemove
     onmouseover = stackonmouseover
@@ -867,6 +882,6 @@ private func evaluate(_ node: String, _ attrs: [String: String?] = [:], _ closur
     cellspacing = stackcellspacing
     marginheight = stackmarginheight
     acceptCharset = stackacceptCharset
-    
+
     inner = stackinner
 }


### PR DESCRIPTION
- Added the `manifest`, `ontouchstart` and `dataText` vars to Scopes
- Made HttpResponse `headers()` and `statusCode` public, `statusCode` a computed variable.

These are just a few minor changes that I've made for a project I'm using Swifter for.
Making the response properties public is necessary to create custom middle-middle-wares (proper terminology? /shrug) like the ones I'm using below:

```swift
typealias HTTPMiddleware = ((HttpRequest) -> HttpResponse)
typealias ThrowableHTTPMiddleware = ((HttpRequest) throws -> HttpResponse)

let TryingRequestHandler: (@escaping ThrowableHTTPMiddleware) -> HTTPMiddleware = { requestHandler in
  return {
    do {
      return try requestHandler($0)
    } catch let error {
      return .badRequest(.text(error.localizedDescription))
    }
  }
}

let LoggingRequestHandler: (@escaping HTTPMiddleware) -> HTTPMiddleware = { requestHandler in
  return { request in
    let startTime = Date()
    let response = requestHandler(request)
    let stopTime = Date()
    defer {
      loggingQueue.async {
        let pinfo = ProcessInfo.processInfo
        let df = (DateFormatter())
        df.dateFormat = "MMM dd HH:mm:ss"
        
        let date = df.string(from: startTime)
        let host = Info.hostname
        let proc = pinfo.processName
        let pid  = pinfo.processIdentifier
        let addr = request.address ?? "127.0.0.1"
        let time = stopTime.timeIntervalSince(startTime)
        let meth = request.method
        let path = request.path
        let stat = response.statusCode
        let len  = response.headers()["Content-Length"] ?? "0"
        let org  = request.headers["origin"] ?? "\"-\""
        let hdrs = request.headers["user-agent"] ?? ""

        print("\(date) \(host) \(proc)[\(pid)]: \(addr) - - Time Taken:\(time)  \"\(meth) \(path) HTTP/1.1\" \(stat) \(len) \"\(org)\" \"\(hdrs)\"")
      }
    }
    return response
  }
}
```

These can be combined/chained to wrap around request handlers, and are extremely easy to add to normal request handling closures by dropping the name right in front, examples:
```swift
// Works with normal requests
server.GET["/refresh"] = LoggingRequestHandler { request in
  doRefreshStuff()
  return .ok(.text("OK"))
}

// Trying request Handler automatically responds to errors with a .badRequest wrapping localizedDescription, no need to do/catch!
server.GET["/info"] = TryingRequestHandler { request in
  return .ok(.text(try getInfoJson()))
}

// You can even chain them!  Keep in mind the TryingRequestHandler is the one that takes a throwing block so it should be inner, and it has to be "function like" so wrap the whole block in parens
server.GET["/somethingElse"] = LoggingRequestHandler( TryingReqeustHandler { request in
  try doOtherThing()
  return .ok(.text("OK"))
})

// Use like a function for shared files or scopes
server["js/compiled/:path"]  = LoggingRequestHandler(shareFilesFromDirectory("/path/to/resources"))
server.GET["/"] = LoggingRequestHandler(scopes { ... })

// Maybe even WebSockets?  IDK havent tested but the syntax works
server["/websocket-echo"] = LoggingRequestHandler(websocket(text: { session, text in
  session.writeText(text)
}, binary: { session, binary in
  session.writeBinary(binary)
}))

```