### PR TITLE
Changes HttpResponse html(String) behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. Changes not
 - A new `CHANGELOG.md` to keep track of changes in the project. ([#385](https://github.com/httpswift/swifter/pull/385)) by [@Vkt0r](https://github.com/Vkt0r)
 - Added [Danger](https://danger.systems/ruby/) and Swiftlint to the project. ([#398](https://github.com/httpswift/swifter/pull/398)) by [@Vkt0r](https://github.com/Vkt0r)
 - Added the following to `Scopes`: `manifest`, `ontouchstart`, `dataText`. ([#410](https://github.com/httpswift/swifter/pull/410)) by [@apocolipse](https://github.com/apocolipse)
+- Added `htmlBody(String)` to `HttpResonse`  as a compability case for the changed `html(String)` case.
 
 ## Fixed
 - An issue causing a crash regarding a thread race condition. ([#399](https://github.com/httpswift/swifter/pull/399)) by [@Vkt0r](https://github.com/Vkt0r)
@@ -37,7 +38,8 @@ All notable changes to this project will be documented in this file. Changes not
 - Refactor: Use Foundation API for Base64 encoding. ([#403](https://github.com/httpswift/swifter/pull/403)) by [@mazyod](https://github.com/mazyod)
 - Refactor: Use `URLComponents` for `HttpRequest` path and query parameters parsing [#404](https://github.com/httpswift/swifter/pull/404)) by [@mazyod](https://github.com/mazyod)
 - `HttpResponse` functions `statusCode()` and `reasonPhrase` changed to computed variables instead of functions, and made public (No impact on existing usage as it was previously internal). ([#410](https://github.com/httpswift/swifter/pull/410)) by [@apocolipse](https://github.com/apocolipse)
-
+- `HttpResponse`: `html` requires now a complete html-string, not only the body-part.
+- Include the `CHANGELOG.md` and `README.md` in the Xcode-Project for easy access / changes.
 
 ## Removed
 - Dropped macOS 10.9 support [#404](https://github.com/httpswift/swifter/pull/404)), [#408](https://github.com/httpswift/swifter/pull/408)) by [@mazyod](https://github.com/mazyod), [@Vkt0r](https://github.com/Vkt0r)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tiny http server engine written in [Swift](https://developer.apple.com/swift/) p
 ### How to start?
 ```swift
 let server = HttpServer()
-server["/hello"] = { .ok(.html("You asked for \($0)"))  }
+server["/hello"] = { .ok(.htmlBody("You asked for \($0)"))  }
 server.start()
 ```
 

--- a/XCode/Sources/DemoServer.swift
+++ b/XCode/Sources/DemoServer.swift
@@ -30,7 +30,7 @@ public func demoServer(_ publicDir: String) -> HttpServer {
         }
     }
     
-    server["/magic"] = { .ok(.html("You asked for " + $0.path)) }
+    server["/magic"] = { .ok(.htmlBody("You asked for " + $0.path)) }
     
     server["/test/:param1/:param2"] = { request in
         scopes {
@@ -98,7 +98,7 @@ public func demoServer(_ publicDir: String) -> HttpServer {
             guard let name = multipart.name, let fileName = multipart.fileName else { continue }
             response += "Name: \(name) File name: \(fileName) Size: \(multipart.body.count)<br>"
         }
-        return HttpResponse.ok(.html(response))
+        return HttpResponse.ok(.htmlBody(response))
     }
     
     server.GET["/login"] = scopes {
@@ -136,7 +136,7 @@ public func demoServer(_ publicDir: String) -> HttpServer {
     
     server.POST["/login"] = { request in
         let formFields = request.parseUrlencodedForm()
-        return HttpResponse.ok(.html(formFields.map({ "\($0.0) = \($0.1)" }).joined(separator: "<br>")))
+        return HttpResponse.ok(.htmlBody(formFields.map({ "\($0.0) = \($0.1)" }).joined(separator: "<br>")))
     }
     
     server["/demo"] = scopes {
@@ -165,11 +165,11 @@ public func demoServer(_ publicDir: String) -> HttpServer {
     server["/long"] = { _ in
         var longResponse = ""
         for index in 0..<1000 { longResponse += "(\(index)),->" }
-        return .ok(.html(longResponse))
+        return .ok(.htmlBody(longResponse))
     }
     
     server["/wildcard/*/test/*/:param"] = { request in
-        return .ok(.html(request.path))
+        return .ok(.htmlBody(request.path))
     }
     
     server["/stream"] = { _ in

--- a/XCode/Sources/HttpResponse.swift
+++ b/XCode/Sources/HttpResponse.swift
@@ -24,6 +24,7 @@ public enum HttpResponseBody {
 
     case json(AnyObject)
     case html(String)
+    case htmlBody(String)
     case text(String)
     case data(Data)
     case custom(Any, (Any) throws -> String)
@@ -51,7 +52,12 @@ public enum HttpResponseBody {
                 return (data.count, {
                     try $0.write(data)
                 })
-            case .html(let body):
+            case .html(let html):
+                let data = [UInt8](html.utf8)
+                return (data.count, {
+                    try $0.write(data)
+                })
+            case .htmlBody(let body):
                 let serialised = "<html><meta charset=\"UTF-8\"><body>\(body)</body></html>"
                 let data = [UInt8](serialised.utf8)
                 return (data.count, {

--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		269B47A11D3AAAE20042D137 /* Swifter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swifter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		269B47A41D3AAC4F0042D137 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		269B47A51D3AAC4F0042D137 /* SwiftertvOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftertvOS.h; sourceTree = "<group>"; };
+		540CA839228F275B00A3AF9B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		540CA83A228F275B00A3AF9B /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		6A0D4511204E9988000A0726 /* MimeTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypesTests.swift; sourceTree = "<group>"; };
 		6AE2FF702048011A00302EC4 /* MimeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypes.swift; sourceTree = "<group>"; };
 		7AE893E71C05127900A29F63 /* Swifter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swifter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -354,6 +356,8 @@
 		7C839B6519422CFF003A6950 = {
 			isa = PBXGroup;
 			children = (
+				540CA83A228F275B00A3AF9B /* CHANGELOG.md */,
+				540CA839228F275B00A3AF9B /* README.md */,
 				7B912F4B220507DB0062C360 /* LinuxMain.swift */,
 				7C76B6E91D2C44F30030FC98 /* Sources */,
 				7CA4815619A2EF2B0030B30D /* Resources */,

--- a/XCode/SwifterSampleOSX/main.swift
+++ b/XCode/SwifterSampleOSX/main.swift
@@ -10,7 +10,7 @@ import Swifter
 do {
     let server = demoServer(try String.File.currentWorkingDirectory())
     server["/testAfterBaseRoute"] = { request in
-        return .ok(.html("ok !"))
+        return .ok(.htmlBody("ok !"))
     }
     
     if #available(OSXApplicationExtension 10.10, *) {

--- a/XCode/Tests/ServerThreadingTests.swift
+++ b/XCode/Tests/ServerThreadingTests.swift
@@ -32,7 +32,7 @@ class ServerThreadingTests: XCTestCase {
         let queue = DispatchQueue(label: "com.swifter.threading")
         let hostURL: URL
         
-        server.GET[path] = { .ok(.html("You asked for " + $0.path)) }
+        server.GET[path] = { .ok(.htmlBody("You asked for " + $0.path)) }
         
         do {
             
@@ -70,7 +70,7 @@ class ServerThreadingTests: XCTestCase {
     func testShouldHandleTheSameRequestConcurrently() {
         
         let path = "/a/:b/c"
-        server.GET[path] = { .ok(.html("You asked for " + $0.path)) }
+        server.GET[path] = { .ok(.htmlBody("You asked for " + $0.path)) }
         
         var requestExpectation: XCTestExpectation? = expectation(description: "Should handle the request concurrently")
         

--- a/XCode/Tests/SwifterTestsHttpRouter.swift
+++ b/XCode/Tests/SwifterTestsHttpRouter.swift
@@ -26,7 +26,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterSlashRoot() {
         
         router.register(nil, path: "/", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNotNil(router.route(nil, path: "/"))
@@ -35,7 +35,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterSimplePathSegments() {
         
         router.register(nil, path: "/a/b/c/d", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))
@@ -48,7 +48,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterSinglePathSegmentWildcard() {
         
         router.register(nil, path: "/a/*/c/d", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))
@@ -62,7 +62,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterVariables() {
         
         router.register(nil, path: "/a/:arg1/:arg2/b/c/d/:arg3", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))
@@ -76,7 +76,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterMultiplePathSegmentWildcards() {
         
         router.register(nil, path: "/a/**/e/f/g", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))
@@ -88,11 +88,11 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterEmptyTail() {
         
         router.register(nil, path: "/a/b/", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         router.register(nil, path: "/a/b/:var", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))
@@ -108,7 +108,7 @@ class SwifterTestsHttpRouter: XCTestCase {
     func testHttpRouterPercentEncodedPathSegments() {
         
         router.register(nil, path: "/a/<>/^", handler: { _ in
-            return .ok(.html("OK"))
+            return .ok(.htmlBody("OK"))
         })
         
         XCTAssertNil(router.route(nil, path: "/"))


### PR DESCRIPTION
This PR makes two changes:
- Adds `CHANGELOG.md` and `README.md` to the Xcode-Project for easy access
- Changes the behaviour for `HttpResponse` case `html`: This case now needs a full html-string (not only the body-part). For compatibility reason we added a `htmlBody` case as well, that case will only need the body-part then.

We need to provide a full html-string (with a custom head section), unfortunately the existing `html` case in `HttpResonse` always provides a fix head-part (that is probably perfectly fine for most cases).

As this PR makes this version incompatible to previous ones in terms of the `html` response I would certainly understand any vetos. Then again the case is called `html` and not `htmlBody` so it is / might be misleading anyhow - so IMHO would recommend changing the behaviour as this PR provides.