### PR TITLE
Set the version of the HTTP Server based in the project version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ All notable changes to this project will be documented in this file. Changes not
 
 ## Added
 
-- Add the `trailing_whitespace` rule in Swiftlint and autocorrect all the source files. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
+- Add the `trailing_whitespace` rule in Swiftlint and autocorrect all the source files. ([#421](https://github.com/httpswift/swifter/pull/421)) by [@Vkt0r](https://github.com/Vkt0r)
+
+## Changed
+
+- Set the version of the HTTP Server based in the project version in the **Info.plist** for macOS, iOS and tvOS platforms. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
 
 # [1.4.7] 
 

--- a/XCode/Sources/HttpServer.swift
+++ b/XCode/Sources/HttpServer.swift
@@ -9,7 +9,16 @@ import Foundation
 
 public class HttpServer: HttpServerIO {
 
-    public static let VERSION = "1.4.7"
+    public static let VERSION: String = {
+
+        #if os(Linux)
+        return "1.4.7"
+        #else
+        let bundle = Bundle(for: HttpServer.self)
+        guard let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String else { return "Unspecified" }
+        return version
+        #endif
+    }()
 
     private let router = HttpRouter()
 


### PR DESCRIPTION
* Set the version of the HTTP Server based in the project version in the **Info.plist** for iOS, macOS, and tvOS. (The use of `Bundle` is not yet in Linux)