### PR TITLE
Use the machine executor in CircleCI for Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,16 @@ jobs:
           path: /tmp/test-results
 
   Test Linux Platform:
-    docker:
-      - image: swift:5.0
+    machine: 
+      docker_layer_caching: true
     steps:
       - checkout
-      - run: 
+      - run:
+          name: Build Docker Image
+          command: docker build --tag swift5.0 .
+      - run:
           name: Run Unit Tests
-          command: swift test
+          command: docker run --rm swift5.0
 
 workflows:
   version: 2

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.build/
+!.build/checkouts/
+!.build/repositories/
+!.build/workspace-state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file. Changes not
 
 - Add the `trailing_whitespace` rule in Swiftlint and autocorrect all the source files. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
 
+## Changed
+
+- Use the machine executor (https://circleci.com/docs/2.0/executor-types/#using-machine) which gives us 8GB of RAM and avoid the issues with the Linux Docker image. ([#422](https://github.com/httpswift/swifter/pull/422)) by [@Vkt0r](https://github.com/Vkt0r)
+
 # [1.4.7] 
 
 ## Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM swift:5.0
+
+WORKDIR /package
+
+COPY . ./
+
+RUN swift package resolve
+RUN swift package clean
+CMD swift test


### PR DESCRIPTION
* Use the machine executor (https://circleci.com/docs/2.0/executor-types/#using-machine) which gives us 8GB of RAM and avoid the issues with the Linux Docker image.
* Add a `Dockerfile` and the `.dockerignore` with all the details to run Docker with Swift 5.0 in Linux