### PR TITLE
fix parsing url strings with brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ All notable changes to this project will be documented in this file. Changes not
 ## Changed
 
 - Set the version of the HTTP Server based in the project version in the **Info.plist** for macOS, iOS and tvOS platforms. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
-- Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`
-- Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings
+- Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
+- Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 
 # [1.4.7] 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be documented in this file. Changes not
 ## Changed
 
 - Set the version of the HTTP Server based in the project version in the **Info.plist** for macOS, iOS and tvOS platforms. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
+- Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`
+- Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings
 
 # [1.4.7] 
 

--- a/XCode/Sources/HttpParser.swift
+++ b/XCode/Sources/HttpParser.swift
@@ -23,7 +23,8 @@ public class HttpParser {
         }
         let request = HttpRequest()
         request.method = statusLineTokens[0]
-        let urlComponents = URLComponents(string: statusLineTokens[1])
+        let encodedPath = statusLineTokens[1].addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? statusLineTokens[1]
+        let urlComponents = URLComponents(string: encodedPath)
         request.path = urlComponents?.path ?? ""
         request.queryParams = urlComponents?.queryItems?.map { ($0.name, $0.value ?? "") } ?? []
         request.headers = try readHeaders(socket)

--- a/XCode/Tests/SwifterTestsHttpParser.swift
+++ b/XCode/Tests/SwifterTestsHttpParser.swift
@@ -166,7 +166,7 @@ class SwifterTestsHttpParser: XCTestCase {
         XCTAssertEqual(resp?.headers["header1"], "1", "Parser should extract multiple headers from the request.")
         XCTAssertEqual(resp?.headers["header2"], "2", "Parser should extract multiple headers from the request.")
 
-        resp = try? parser.readHttpRequest(TestSocket("GET https://www.example.com/some/path?subscript_query[]=1&subscript_query[]=2 HTTP/1.0\nContent-Length: 10\n\n1234567890"))
+        resp = try? parser.readHttpRequest(TestSocket("GET /some/path?subscript_query[]=1&subscript_query[]=2 HTTP/1.0\nContent-Length: 10\n\n1234567890"))
         let queryPairs = resp?.queryParams ?? []
         XCTAssertEqual(queryPairs.count, 2)
         XCTAssertEqual(queryPairs.first?.0, "subscript_query[]")

--- a/XCode/Tests/SwifterTestsHttpParser.swift
+++ b/XCode/Tests/SwifterTestsHttpParser.swift
@@ -165,5 +165,17 @@ class SwifterTestsHttpParser: XCTestCase {
         resp = try? parser.readHttpRequest(TestSocket("GET / HTTP/1.0\nHeader1: 1\nHeader2: 2\nContent-Length: 0\n\n"))
         XCTAssertEqual(resp?.headers["header1"], "1", "Parser should extract multiple headers from the request.")
         XCTAssertEqual(resp?.headers["header2"], "2", "Parser should extract multiple headers from the request.")
+
+        resp = try? parser.readHttpRequest(TestSocket("GET https://www.example.com/some/path?subscript_query[]=1&subscript_query[]=2 HTTP/1.0\nContent-Length: 10\n\n1234567890"))
+        let queryPairs = resp?.queryParams ?? []
+        XCTAssertEqual(queryPairs.count, 2)
+        XCTAssertEqual(queryPairs.first?.0, "subscript_query[]")
+        XCTAssertEqual(queryPairs.first?.1, "1")
+        XCTAssertEqual(queryPairs.last?.0, "subscript_query[]")
+        XCTAssertEqual(queryPairs.last?.1, "2")
+        XCTAssertEqual(resp?.method, "GET", "Parser should extract HTTP method name from the status line.")
+        XCTAssertEqual(resp?.path, "/some/path", "Parser should extract HTTP path value from the status line.")
+        XCTAssertEqual(resp?.headers["content-length"], "10", "Parser should extract Content-Length header value.")
+
     }
 }

--- a/XCode/Tests/XCTestManifests.swift
+++ b/XCode/Tests/XCTestManifests.swift
@@ -97,6 +97,7 @@ extension SwifterTestsWebSocketSession {
 
 public func __allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(IOSafetyTests.__allTests__IOSafetyTests),
         testCase(MimeTypeTests.__allTests__MimeTypeTests),
         testCase(ServerThreadingTests.__allTests__ServerThreadingTests),
         testCase(SwifterTestsHttpParser.__allTests__SwifterTestsHttpParser),

--- a/XCode/Tests/XCTestManifests.swift
+++ b/XCode/Tests/XCTestManifests.swift
@@ -97,7 +97,6 @@ extension SwifterTestsWebSocketSession {
 
 public func __allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(IOSafetyTests.__allTests__IOSafetyTests),
         testCase(MimeTypeTests.__allTests__MimeTypeTests),
         testCase(ServerThreadingTests.__allTests__ServerThreadingTests),
         testCase(SwifterTestsHttpParser.__allTests__SwifterTestsHttpParser),


### PR DESCRIPTION
There seems to be an issue (on ios at least) where URLs with `[]` query parameters are not parsed; URLComponents will produce `nil` so routing won't succeed.

This fix escapes the strings by percent-encoding them so query parameters should now work as expected.

Added unit test for such a case