### PR TITLE
SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ server["/websocket-echo"] = websocket(text: { session, text in
 })
 server.start()
 ```
+### How to TLS/SSL?
+Currently only supported on Darwin OS
+```swift
+let server = HttpServer()
+server.sslCertificate = TLS.loadP12Certificate(certificateData, certificatePassword)
+server.start()
+```
 ### CocoaPods? Yes.
 ```ruby
 use_frameworks!

--- a/XCode/Sources/Errno.swift
+++ b/XCode/Sources/Errno.swift
@@ -16,10 +16,21 @@ public class Errno {
 
     #if !os(Linux)
     public class func sslError(from status: OSStatus) -> Error {
-        guard let msg = SecCopyErrorMessageString(status, nil) else {
+        guard let msg = getMessage(from: status) else {
             return SocketError.tlsSessionFailed("<\(status): message is not provided>")
         }
-        return SocketError.tlsSessionFailed(msg as NSString as String)
+        return SocketError.tlsSessionFailed(msg)
+    }
+
+    private class func getMessage(from status: OSStatus) -> String? {
+        if #available(iOS 11.3, tvOS 11.3, *) {
+            guard let msg = SecCopyErrorMessageString(status, nil) else {
+                return nil
+            }
+            return msg as String
+        } else {
+            return "SSL error (\(status))"
+        }
     }
     #endif
 }

--- a/XCode/Sources/Errno.swift
+++ b/XCode/Sources/Errno.swift
@@ -13,4 +13,13 @@ public class Errno {
         // https://forums.developer.apple.com/thread/113919
         return String(cString: strerror(errno))
     }
+
+    #if !os(Linux)
+    public class func sslError(from status: OSStatus) -> Error {
+        guard let msg = SecCopyErrorMessageString(status, nil) else {
+            return SocketError.tlsSessionFailed("<\(status): message is not provided>")
+        }
+        return SocketError.tlsSessionFailed(msg as NSString as String)
+    }
+    #endif
 }

--- a/XCode/Sources/Socket.swift
+++ b/XCode/Sources/Socket.swift
@@ -10,6 +10,9 @@ import Foundation
 public enum SocketError: Error {
     case socketCreationFailed(String)
     case socketSettingReUseAddrFailed(String)
+    #if !os(Linux)
+    case tlsSessionFailed(String)
+    #endif
     case bindFailed(String)
     case listenFailed(String)
     case writeFailed(String)

--- a/XCode/Sources/Socket.swift
+++ b/XCode/Sources/Socket.swift
@@ -59,7 +59,7 @@ open class Socket: Hashable, Equatable {
     #if !os(Linux)
     public func startTlsSession(with certificate: CFArray) throws {
         tls = try TlsSession(fd: socketFileDescriptor, certificate: certificate)
-        // TODO: perform handshake
+        try tls?.handshake()
     }
     #endif
 

--- a/XCode/Sources/Socket.swift
+++ b/XCode/Sources/Socket.swift
@@ -47,6 +47,12 @@ open class Socket: Hashable, Equatable {
         Socket.close(self.socketFileDescriptor)
     }
 
+    #if !os(Linux)
+    public func startTlsSession(with certificate: CFArray) {
+        // TODO: TLS session init and setup
+    }
+    #endif
+
     public func port() throws -> in_port_t {
         var addr = sockaddr_in()
         return try withUnsafePointer(to: &addr) { pointer in

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -34,7 +34,9 @@ public enum TLS {
             throw SocketError.tlsSessionFailed("Could not retrieve p12 data from given certificate")
         }
         // must be force casted, will be fixed in swift 5 https://bugs.swift.org/browse/SR-7015
+        // swiftlint:disable force_cast
         let secIdentity = dictionary[kSecImportItemIdentity as String] as! SecIdentity
+        // swiftlint:enable force_cast
         let chainWithoutIdentity = chain.dropFirst()
         let certs = [secIdentity] + chainWithoutIdentity.map { $0 as Any }
         return certs as CFArray

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -45,6 +45,14 @@ open class TlsSession {
         SSLClose(context)
         fdPtr.deallocate()
     }
+
+    open func handshake() throws {
+        var status: OSStatus = -1
+        repeat {
+            status = SSLHandshake(context)
+        } while status == errSSLWouldBlock
+        try ensureNoErr(status)
+    }
 }
 
 private func sslWrite(connection: SSLConnectionRef, data: UnsafeRawPointer, dataLength: UnsafeMutablePointer<Int>) -> OSStatus {

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -27,4 +27,68 @@ public enum TLS {
         return certs as CFArray
     }
 }
+
+open class TlsSession {
+
+    private let context: SSLContext
+    private var fdPtr = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+
+    init(fd: Int32, certificate: CFArray) throws {
+        context = SSLCreateContext(nil, .serverSide, .streamType)!
+        fdPtr.pointee = fd
+        try ensureNoErr(SSLSetIOFuncs(context, sslRead, sslWrite))
+        try ensureNoErr(SSLSetConnection(context, fdPtr))
+        try ensureNoErr(SSLSetCertificate(context, certificate))
+    }
+
+    open func close() {
+        SSLClose(context)
+        fdPtr.deallocate()
+    }
+}
+
+private func sslWrite(connection: SSLConnectionRef, data: UnsafeRawPointer, dataLength: UnsafeMutablePointer<Int>) -> OSStatus {
+    let fd = connection.assumingMemoryBound(to: Int32.self).pointee
+    let bytesToWrite = dataLength.pointee
+
+    let written = Darwin.write(fd, data, bytesToWrite)
+
+    dataLength.pointee = written
+    if written > 0 {
+        return written < bytesToWrite ? errSSLWouldBlock : noErr
+    }
+    if written == 0 {
+        return errSSLClosedGraceful
+    }
+
+    dataLength.pointee = 0
+    return errno == EAGAIN ? errSSLWouldBlock : errSecIO
+}
+
+private func sslRead(connection: SSLConnectionRef, data: UnsafeMutableRawPointer, dataLength: UnsafeMutablePointer<Int>) -> OSStatus {
+    let fd = connection.assumingMemoryBound(to: Int32.self).pointee
+    let bytesToRead = dataLength.pointee
+    let read = recv(fd, data, bytesToRead, 0)
+
+    dataLength.pointee = read
+    if read > 0 {
+        return read < bytesToRead ? errSSLWouldBlock : noErr
+    }
+
+    if read == 0 {
+        return errSSLClosedGraceful
+    }
+
+    dataLength.pointee = 0
+    switch errno {
+    case ENOENT:
+        return errSSLClosedGraceful
+    case EAGAIN:
+        return errSSLWouldBlock
+    case ECONNRESET:
+        return errSSLClosedAbort
+    default:
+        return errSecIO
+    }
+}
 #endif

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -15,6 +15,14 @@ private func ensureNoErr(_ status: OSStatus) throws {
 }
 
 public enum TLS {
+    /// Imports .p12 certificate file constructing structure to be used in TLS session.
+    ///
+    /// See [SecPKCS12Import](https://developer.apple.com/documentation/security/1396915-secpkcs12import).
+    /// Apple docs contain a misleading information that it does not import items to Keychain even though
+    /// it does.
+    ///
+    /// - Parameter _data: .p12 certificate file content
+    /// - Parameter password: password used when importing certificate
     public static func loadP12Certificate(_ _data: Data, _ password: String) throws -> CFArray {
         let data = _data as NSData
         let options = [kSecImportExportPassphrase: password]

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -1,0 +1,30 @@
+//
+//  HttpRouter.swift
+//  Swifter
+//
+//  Copyright (c) 2014-2016 Damian Kołakowski. All rights reserved.
+//
+
+import Foundation
+
+#if !os(Linux)
+private func ensureNoErr(_ status: OSStatus) throws {
+    guard status == noErr else {
+        throw Errno.sslError(from: status)
+    }
+}
+
+public enum TLS {
+    public static func loadP12Certificate(_ _data: Data, _ password: String) throws -> CFArray {
+        let data = _data as NSData
+        let options = [kSecImportExportPassphrase: password]
+        var items: CFArray!
+        try ensureNoErr(SecPKCS12Import(data, options as NSDictionary, &items))
+        let dictionary = (items! as [AnyObject])[0]
+        let secIdentity = dictionary[kSecImportItemIdentity] as! SecIdentity
+        let chain = dictionary[kSecImportItemCertChain] as! [SecCertificate]
+        let certs = [secIdentity] + chain.dropFirst().map { $0 as Any }
+        return certs as CFArray
+    }
+}
+#endif

--- a/XCode/Sources/TlsSession.swift
+++ b/XCode/Sources/TlsSession.swift
@@ -53,6 +53,34 @@ open class TlsSession {
         } while status == errSSLWouldBlock
         try ensureNoErr(status)
     }
+
+    /// Write up to `length` bytes to TLS session from a buffer `pointer` points to.
+    ///
+    /// - Returns: The number of bytes written
+    /// - Throws: SocketError.tlsSessionFailed if unable to write to the session
+    open func writeBuffer(_ pointer: UnsafeRawPointer, length: Int) throws -> Int {
+        var written = 0
+        try ensureNoErr(SSLWrite(context, pointer, length, &written))
+        return written
+    }
+
+    /// Read a single byte off the TLS session.
+    ///
+    /// - Throws: SocketError.tlsSessionFailed if unable to read from the session
+    open func readByte(_ byte: UnsafeMutablePointer<UInt8>) throws {
+        _ = try read(into: byte, length: 1)
+    }
+
+    /// Read up to `length` bytes from TLS session into an existing buffer
+    ///
+    /// - Parameter into: The buffer to read into (must be at least length bytes in size)
+    /// - Returns: The number of bytes read
+    /// - Throws: SocketError.tlsSessionFailed if unable to read from the session
+    open func read(into buffer: UnsafeMutablePointer<UInt8>, length: Int) throws -> Int {
+        var received = 0
+        try ensureNoErr(SSLRead(context, buffer, length, &received))
+        return received
+    }
 }
 
 private func sslWrite(connection: SSLConnectionRef, data: UnsafeRawPointer, dataLength: UnsafeMutablePointer<Int>) -> OSStatus {

--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		039CE04222F32BA600C9788F /* TlsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039CE04122F32BA600C9788F /* TlsSession.swift */; };
+		039CE04322F32BA600C9788F /* TlsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039CE04122F32BA600C9788F /* TlsSession.swift */; };
+		039CE04422F32BA600C9788F /* TlsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039CE04122F32BA600C9788F /* TlsSession.swift */; };
 		043660C721FED34100497989 /* Swifter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AE893FB1C0512C400A29F63 /* Swifter.framework */; };
 		043660CD21FED35200497989 /* SwifterTestsHttpRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCB8C5F1D97B8CC008B9712 /* SwifterTestsHttpRouter.swift */; };
 		043660CE21FED35500497989 /* SwifterTestsHttpParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCD876D1C660B250068099B /* SwifterTestsHttpParser.swift */; };
@@ -164,6 +167,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		039CE04122F32BA600C9788F /* TlsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TlsSession.swift; sourceTree = "<group>"; };
 		043660C221FED34100497989 /* SwiftermacOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftermacOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		043660C621FED34100497989 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		043660DA21FED3A300497989 /* SwiftertvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftertvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -353,6 +357,7 @@
 				7C76B2A11D369C9D00D35BFB /* Errno.swift */,
 				7C377E161D964B6A009C6148 /* String+File.swift */,
 				6AE2FF702048011A00302EC4 /* MimeTypes.swift */,
+				039CE04122F32BA600C9788F /* TlsSession.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -818,6 +823,7 @@
 				269B47901D3AAAE20042D137 /* DemoServer.swift in Sources */,
 				269B47921D3AAAE20042D137 /* Socket+File.swift in Sources */,
 				269B47931D3AAAE20042D137 /* Socket.swift in Sources */,
+				039CE04422F32BA600C9788F /* TlsSession.swift in Sources */,
 				269B47941D3AAAE20042D137 /* HttpServerIO.swift in Sources */,
 				269B47951D3AAAE20042D137 /* Files.swift in Sources */,
 				2659FC1A1DADC077003F3930 /* String+File.swift in Sources */,
@@ -845,6 +851,7 @@
 				7C76B7151D2C45760030FC98 /* HttpRequest.swift in Sources */,
 				7C76B70D1D2C456A0030FC98 /* DemoServer.swift in Sources */,
 				7C76B29F1D369BEC00D35BFB /* Socket+File.swift in Sources */,
+				039CE04222F32BA600C9788F /* TlsSession.swift in Sources */,
 				7C76B7231D2C45890030FC98 /* Socket.swift in Sources */,
 				7C76B71D1D2C45820030FC98 /* HttpServerIO.swift in Sources */,
 				7C76B7111D2C45710030FC98 /* Files.swift in Sources */,
@@ -872,6 +879,7 @@
 				7C76B7161D2C45760030FC98 /* HttpRequest.swift in Sources */,
 				7C76B70E1D2C456B0030FC98 /* DemoServer.swift in Sources */,
 				7C76B2A01D369BEC00D35BFB /* Socket+File.swift in Sources */,
+				039CE04322F32BA600C9788F /* TlsSession.swift in Sources */,
 				7C76B7241D2C458A0030FC98 /* Socket.swift in Sources */,
 				7C76B71E1D2C45820030FC98 /* HttpServerIO.swift in Sources */,
 				7C76B7121D2C45710030FC98 /* Files.swift in Sources */,

--- a/XCode/SwifterSampleOSX/main.swift
+++ b/XCode/SwifterSampleOSX/main.swift
@@ -7,6 +7,23 @@
 import Foundation
 import Swifter
 
+/// For demo purposes certificate is expected to be at location
+/// ~/.swifter/localhost.p12
+///
+/// the easiest way to create certificate for localhost is using `mkcert` tool
+private func certificateData() -> Data? {
+    guard let homePath = ProcessInfo.processInfo.environment["HOME"] else {
+        return nil
+    }
+    guard let homeUrl = URL(string: homePath) else {
+        return nil
+    }
+    let certPath = homeUrl
+        .appendingPathComponent(".swifter", isDirectory: true)
+        .appendingPathComponent("localhost.p12", isDirectory: false)
+    return FileManager.default.contents(atPath: certPath.absoluteString)
+}
+
 do {
     let server = demoServer(try String.File.currentWorkingDirectory())
     server["/testAfterBaseRoute"] = { request in
@@ -14,6 +31,10 @@ do {
     }
 
     if #available(OSXApplicationExtension 10.10, *) {
+        if let certData = certificateData() {
+            server.sslCertificate = try TLS.loadP12Certificate(certData, "changeit")
+            print("SSL certificate loaded")
+        }
         try server.start(9080, forceIPv4: true)
     } else {
         // Fallback on earlier versions


### PR DESCRIPTION
### Motivation

To have SSL support and be able to use HTTPS. The use cases of swifter library will be much broader.
Our company use swifter to run mock API server in iOS UI tests (https://github.com/treatwell/twuitests), but currently arbitrary loads have to be enabled in iOS app because iOS enforces using SSL connections.

### What's in this PR

This PR introduces SSL support using TLS session on Darwin OS (if everything will turn out fine I'll try adding support for Linux OS as well).

Demo optional `localhost` (if appears at `~/.swifter/localhost.p12`) certificate loading is added to `SwifterSampleOSX` target.

Closes #111 #395

### How did I test it?

Using `mkcert` tool:
```bash
mkcert -install
mkcert -pkcs12 localhost 127.0.0.1 ::1
```
and then imported generated `.p12` file to System keychain.