### PR TITLE
Make HttpServer an open class for customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file. Changes not
 
 ## Changed
 
-- Turn `HttpServer` and `HttpServerIO` into open classes to allow for more customization. (#???) by [@cobbal](https://github.com/cobbal)
+- Turn `HttpServer` and `HttpServerIO` into open classes to allow for more customization. ([#443](https://github.com/httpswift/swifter/pull/443)) by [@cobbal](https://github.com/cobbal)
 - Set the version of the HTTP Server based in the project version in the **Info.plist** for macOS, iOS and tvOS platforms. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
 - Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. Changes not
 
 ## Changed
 
+- Turn `HttpServer` and `HttpServerIO` into open classes to allow for more customization. (#???) by [@cobbal](https://github.com/cobbal)
 - Set the version of the HTTP Server based in the project version in the **Info.plist** for macOS, iOS and tvOS platforms. ([#416](https://github.com/httpswift/swifter/pull/416)) by [@Vkt0r](https://github.com/Vkt0r)
 - Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)

--- a/Dangerfile
+++ b/Dangerfile
@@ -26,7 +26,7 @@ swiftlint.config_file = '.swiftlint.yml'
 swiftlint.lint_files
 
 # Warn when new tests are added but the XCTestManifests wasn't updated to run on Linux
-tests_added_or_modified = git.modified_files.grep(/XCode\/Tests/).empty? || git.added_files.grep(/XCode\/Tests/).empty?
+tests_added_or_modified = !git.modified_files.grep(/XCode\/Tests/).empty? || !git.added_files.grep(/XCode\/Tests/).empty?
 xc_manifest_updated = !git.modified_files.grep(/XCode\/Tests\/XCTestManifests.swift/).empty?
 if tests_added_or_modified && !xc_manifest_updated
   warn("It seems like you've added new tests to the library. If that's the case, please update the [XCTestManifests.swift](https://github.com/httpswift/swifter/blob/stable/XCode/Tests/XCTestManifests.swift) file running in your terminal the command `swift test --generate-linuxmain`.")

--- a/XCode/Sources/HttpServer.swift
+++ b/XCode/Sources/HttpServer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class HttpServer: HttpServerIO {
+open class HttpServer: HttpServerIO {
 
     public static let VERSION: String = {
 
@@ -56,7 +56,7 @@ public class HttpServer: HttpServerIO {
 
     public var middleware = [(HttpRequest) -> HttpResponse?]()
 
-    override public func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) -> HttpResponse) {
+    override open func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) -> HttpResponse) {
         for layer in middleware {
             if let response = layer(request) {
                 return ([:], { _ in response })

--- a/XCode/Sources/HttpServerIO.swift
+++ b/XCode/Sources/HttpServerIO.swift
@@ -12,7 +12,7 @@ public protocol HttpServerIODelegate: class {
     func socketConnectionReceived(_ socket: Socket)
 }
 
-public class HttpServerIO {
+open class HttpServerIO {
 
     public weak var delegate: HttpServerIODelegate?
 
@@ -111,7 +111,7 @@ public class HttpServerIO {
         self.state = .stopped
     }
 
-    public func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) -> HttpResponse) {
+    open func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) -> HttpResponse) {
         return ([:], { _ in HttpResponse.notFound })
     }
 


### PR DESCRIPTION
Turn `HttpServer` into an open class to allow for slightly more
customization than the `middleware` property allows.

For my particular use case, I'm trying to add some simple logging, which
would be an easy thing to do if I could just put a small wrapper around
`dispatch`.

I only made the `dispatch` method open here, since it seems like an
obviously good customization point that would need inheritance instead
of containment to customize.