### PR TITLE
Fix build warnings from use of `&` to create a pointer to `buffer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. Changes not
 - Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Use `swift_version` CocoaPods DSL. ([#425](https://github.com/httpswift/swifter/pull/425)) by [@dnkoutso](https://github.com/dnkoutso)
+- Fix compiler warnings in Socket+File.swift for iOS, tvOS, and Linux platforms by using `withUnsafeBytes` rather than `&` to get a scoped UnsafeRawPointer.
 
 # [1.4.7] 
 

--- a/XCode/Sources/Socket+File.swift
+++ b/XCode/Sources/Socket+File.swift
@@ -20,11 +20,15 @@ import Foundation
             }
             var writeCounter = 0
             while writeCounter < readResult {
-                #if os(Linux)
-                    let writeResult = send(target, &buffer + writeCounter, readResult - writeCounter, Int32(MSG_NOSIGNAL))
-                #else
-                    let writeResult = write(target, &buffer + writeCounter, readResult - writeCounter)
-                #endif
+                let writeResult = buffer.withUnsafeBytes { (ptr) -> Int in
+                  let start = ptr.baseAddress! + writeCounter
+                  let len = readResult - writeCounter
+                  #if os(Linux)
+                  return send(target, start, len, Int32(MSG_NOSIGNAL))
+                  #else
+                  return write(target, start, len)
+                  #endif
+                }
                 guard writeResult > 0 else {
                     return Int32(writeResult)
                 }


### PR DESCRIPTION
Use withUnsafeBytes() instead, as recommended.

The warnings (which occur only on Linux, iOS, and tvOs) are:
```
/root/.build/checkouts/swifter/XCode/Sources/Socket+File.swift:24:52: warning: inout expression creates a temporary pointer, but argument #1 should be a pointer that outlives the call to '+'
                    let writeResult = send(target, &buffer + writeCounter, readResult - writeCounter, Int32(MSG_NOSIGNAL))
                                                   ^~~~~~~
/root/.build/checkouts/swifter/XCode/Sources/Socket+File.swift:24:52: note: implicit argument conversion from '[UInt8]' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to '+'
                    let writeResult = send(target, &buffer + writeCounter, readResult - writeCounter, Int32(MSG_NOSIGNAL))
                                                   ^~~~~~~
/root/.build/checkouts/swifter/XCode/Sources/Socket+File.swift:24:52: note: use the 'withUnsafeBytes' method on Array in order to explicitly convert argument to buffer pointer valid for a defined scope
                    let writeResult = send(target, &buffer + writeCounter, readResult - writeCounter, Int32(MSG_NOSIGNAL))
```