### PR TITLE
Import FoundationNetworking on Linux to fix tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ All notable changes to this project will be documented in this file. Changes not
 - Update `HttpParser` so it percent-encodes the URL components before initializing `URLComponents`. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Update `SwifterTestsHttpParser` with a test for parsing bracketed query strings. ([#423](https://github.com/httpswift/swifter/pull/423)) by [@nejcvivod](https://github.com/nejcvivod)
 - Use `swift_version` CocoaPods DSL. ([#425](https://github.com/httpswift/swifter/pull/425)) by [@dnkoutso](https://github.com/dnkoutso)
-- Fix compiler warnings in Socket+File.swift for iOS, tvOS, and Linux platforms by using `withUnsafeBytes` rather than `&` to get a scoped UnsafeRawPointer.
+- Fix compiler warnings in Socket+File.swift for iOS, tvOS, and Linux platforms by using `withUnsafeBytes` rather than `&` to get a scoped UnsafeRawPointer ([#445](https://github.com/httpswift/swifter/pull/445)) by [@kbongort](https://github.com/kbongort).
+- Fix tests on linux by importing FoundationNetworking for NSURLSession APIs. ([#446](https://github.com/httpswift/swifter/pull/446)) by [@kbongort](https://github.com/kbongort)
 
 # [1.4.7] 
 

--- a/XCode/Tests/IOSafetyTests.swift
+++ b/XCode/Tests/IOSafetyTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if os(Linux)
+import FoundationNetworking
+#endif
 @testable import Swifter
 
 class IOSafetyTests: XCTestCase {

--- a/XCode/Tests/PingServer.swift
+++ b/XCode/Tests/PingServer.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 @testable import Swifter
 
 // Server

--- a/XCode/Tests/ServerThreadingTests.swift
+++ b/XCode/Tests/ServerThreadingTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if os(Linux)
+import FoundationNetworking
+#endif
 @testable import Swifter
 
 class ServerThreadingTests: XCTestCase {


### PR DESCRIPTION
FoundationNetworking is required for NSURLSession and such.