### PR TITLE
Adds Content-Type to Data HttpResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. Changes not
 
 - Add the `trailing_whitespace` rule in Swiftlint and autocorrect all the source files. ([#421](https://github.com/httpswift/swifter/pull/421)) by [@Vkt0r](https://github.com/Vkt0r)
 - Update the project for Xcode 11.1. ([#438](https://github.com/httpswift/swifter/pull/438)) by [@Vkt0r](https://github.com/Vkt0r)
+- Add optional 'Content-Type' to Data HttpResponse. ([#450](https://github.com/httpswift/swifter/pull/450)) by [@SoftwareEngineerChris](https://github.com/SoftwareEngineerChris)
 
 ## Changed
 

--- a/XCode/Sources/HttpResponse.swift
+++ b/XCode/Sources/HttpResponse.swift
@@ -26,7 +26,7 @@ public enum HttpResponseBody {
     case html(String)
     case htmlBody(String)
     case text(String)
-    case data(Data)
+    case data(Data, contentType: String? = nil)
     case custom(Any, (Any) throws -> String)
 
     func content() -> (Int, ((HttpResponseBodyWriter) throws -> Void)?) {
@@ -56,7 +56,7 @@ public enum HttpResponseBody {
                 return (data.count, {
                     try $0.write(data)
                 })
-            case .data(let data):
+            case .data(let data, _):
                 return (data.count, {
                     try $0.write(data)
                 })
@@ -132,6 +132,7 @@ public enum HttpResponse {
             switch body {
             case .json: headers["Content-Type"] = "application/json"
             case .html: headers["Content-Type"] = "text/html"
+            case .data(_, let contentType): headers["Content-Type"] = contentType
             default:break
             }
         case .movedPermanently(let location):


### PR DESCRIPTION
This PR allows the `Content-Type` HTTP header to be set when using the data `HttpResponse`.