### PR TITLE
allow public access to socket and keep it open when requested

### DIFF
--- a/XCode/Sources/Socket.swift
+++ b/XCode/Sources/Socket.swift
@@ -24,8 +24,13 @@ public enum SocketError: Error {
 // swiftlint: disable identifier_name
 open class Socket: Hashable, Equatable {
 
-    let socketFileDescriptor: Int32
-    private var shutdown = false
+    public let socketFileDescriptor: Int32
+    private var shutdown = false {
+        didSet {
+            if shutdown { didClose?() }
+        }
+    }
+    public var didClose: (() -> ())?
 
     public init(socketFileDescriptor: Int32) {
         self.socketFileDescriptor = socketFileDescriptor

--- a/XCode/Sources/WebSockets.swift
+++ b/XCode/Sources/WebSockets.swift
@@ -150,6 +150,7 @@ public class WebSocketSession: Hashable, Equatable {
     public enum WsError: Error { case unknownOpCode(String), unMaskedFrame(String), protocolError(String), invalidUTF8(String) }
     public enum OpCode: UInt8 { case `continue` = 0x00, close = 0x08, ping = 0x09, pong = 0x0A, text = 0x01, binary = 0x02 }
     public enum Control: Error { case close }
+    public var shouldCloseSocket = true
 
     public class Frame {
         public var opcode = OpCode.close
@@ -167,8 +168,10 @@ public class WebSocketSession: Hashable, Equatable {
     }
 
     deinit {
-        writeCloseFrame()
-        socket.close()
+        if shouldCloseSocket {
+            writeCloseFrame()
+            socket.close()
+        }
     }
 
     public func writeText(_ text: String) {


### PR DESCRIPTION
Hey there, I've been using swifter for a while, but in my case I was always keeping the sockets open, to allow for stateful connections.
In my case communication is bidirectional, the phone acts as a sort of remote for the browser window.

The below are all the changes I needed from this project, would this be something worth merging into the main branch?