### PR TITLE
fix: only escaping invalid data, keep valid escaping untouched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file. Changes not
 - Fix misspell `serialise`. ([#473](https://github.com/httpswift/swifter/pull/473)) by [@mtgto](https://github.com/mtgto)
 - Fix an issue causing Danger was not working properly. ([#486](https://github.com/httpswift/swifter/pull/486)) by [@Vkt0r](https://github.com/Vkt0r)
 - Set Swift version to 5.0 in podspec. ([#475](https://github.com/httpswift/swifter/pull/475)) by [@p-krasnobrovkin-tcs](https://github.com/p-krasnobrovkin-tcs)
+- only escaping invalid data, keep valid escaping untouched ([#484](https://github.com/httpswift/swifter/pull/484)) by [@SolaWing](https://github.com/SolaWing)
 
 ## Changed
 

--- a/Xcode/Sources/HttpParser.swift
+++ b/Xcode/Sources/HttpParser.swift
@@ -24,7 +24,7 @@ public class HttpParser {
         }
         let request = HttpRequest()
         request.method = statusLineTokens[0]
-        let encodedPath = statusLineTokens[1].addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? statusLineTokens[1]
+        let encodedPath = Self.escapingInvalidURL(statusLineTokens[1])
         let urlComponents = URLComponents(string: encodedPath)
         request.path = urlComponents?.path ?? ""
         request.queryParams = urlComponents?.queryItems?.map { ($0.name, $0.value ?? "") } ?? []
@@ -38,7 +38,17 @@ public class HttpParser {
             request.body = try readBody(socket, size: contentLengthValue)
         }
         return request
+    }
+
+    /// only escaping invalid chars，valid encodedPath keep untouched
+    static func escapingInvalidURL(_ url: String) -> String {
+        var urlAllowed: CharacterSet {
+            var allow = CharacterSet.urlQueryAllowed
+            allow.insert(charactersIn: "?#%")
+            return allow
         }
+        return url.addingPercentEncoding(withAllowedCharacters: urlAllowed) ?? url
+    }
 
     private func readBody(_ socket: Socket, size: Int) throws -> [UInt8] {
         return try socket.read(length: size)


### PR DESCRIPTION
this commit avoid escaping twice for query already escaping