### PR TITLE
Update Files.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file. Changes not
 
 - Set `Content-Type` to HttpBody and Text HttpResponse. ([#474](https://github.com/httpswift/swifter/pull/474)) by [@mtgto](https://github.com/mtgto)
 
-- The `shareFile` function now sets `Content-Type` and `Content-Length` headers like `shareFilesFromDirectory. ([#493](https://github.com/httpswift/swifter/pull/493)) by [@jcrate](https://github.com/jcrate)
+- The `shareFile` function now sets `Content-Type` and `Content-Length` headers like `shareFilesFromDirectory`. ([#493](https://github.com/httpswift/swifter/pull/493)) by [@jcrate](https://github.com/jcrate)
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file. Changes not
 
 - Set `Content-Type` to HttpBody and Text HttpResponse. ([#474](https://github.com/httpswift/swifter/pull/474)) by [@mtgto](https://github.com/mtgto)
 
+- The `shareFile` function now sets `Content-Type` and `Content-Length` headers like `shareFilesFromDirectory. ([#493](https://github.com/httpswift/swifter/pull/493)) by [@jcrate](https://github.com/jcrate)
+
 ## Fixed
 
 * Fix misspell `serialise`. ([#473](https://github.com/httpswift/swifter/pull/473)) by [@mtgto](https://github.com/mtgto)

--- a/Xcode/Sources/Files.swift
+++ b/Xcode/Sources/Files.swift
@@ -10,7 +10,14 @@ import Foundation
 public func shareFile(_ path: String) -> ((HttpRequest) -> HttpResponse) {
     return { _ in
         if let file = try? path.openForReading() {
-            return .raw(200, "OK", [:], { writer in
+            let mimeType = path.mimeType()
+            var responseHeader: [String: String] = ["Content-Type": mimeType]
+            
+            if let attr = try? FileManager.default.attributesOfItem(atPath: path),
+                let fileSize = attr[FileAttributeKey.size] as? UInt64 {
+                responseHeader["Content-Length"] = String(fileSize)
+            }
+            return .raw(200, "OK", responseHeader, { writer in
                 try? writer.write(file)
                 file.close()
             })


### PR DESCRIPTION
The `shareFilesFromDirectory` function already sets the content type and length headers on the response. This just adds those headers in the `shareFile` function as well.