### PR TITLE
Fix ** not matching single path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file. Changes not
 - Fix misspell `serialise`. ([#473](https://github.com/httpswift/swifter/pull/473)) by [@mtgto](https://github.com/mtgto)
 - Fix an issue causing Danger was not working properly. ([#486](https://github.com/httpswift/swifter/pull/486)) by [@Vkt0r](https://github.com/Vkt0r)
 - Set Swift version to 5.0 in podspec. ([#475](https://github.com/httpswift/swifter/pull/475)) by [@p-krasnobrovkin-tcs](https://github.com/p-krasnobrovkin-tcs)
+- Fix \*\* not matching against a single path segment. ([#504](https://github.com/httpswift/swifter/pull/504)) by [@michaelenger](https://github.com/michaelenger)
 
 ## Changed
 

--- a/Xcode/Sources/HttpRouter.swift
+++ b/Xcode/Sources/HttpRouter.swift
@@ -158,7 +158,6 @@ open class HttpRouter {
                 }
 
                 let startStarNodeKeys = startStarNode.nodes.keys
-                currentIndex += 1
                 while currentIndex < count, let pathToken = pattern[currentIndex].removingPercentEncoding {
                     currentIndex += 1
                     if startStarNodeKeys.contains(pathToken) {

--- a/Xcode/Tests/SwifterTestsHttpRouter.swift
+++ b/Xcode/Tests/SwifterTestsHttpRouter.swift
@@ -82,7 +82,9 @@ class SwifterTestsHttpRouter: XCTestCase {
         XCTAssertNil(router.route(nil, path: "/"))
         XCTAssertNil(router.route(nil, path: "/a"))
         XCTAssertNotNil(router.route(nil, path: "/a/b/c/d/e/f/g"))
+        XCTAssertNotNil(router.route(nil, path: "/a/b/e/f/g"))
         XCTAssertNil(router.route(nil, path: "/a/e/f/g"))
+        XCTAssertNil(router.route(nil, path: "/a/b/c/f/g"))
     }
 
     func testHttpRouterMultiplePathSegmentWildcardTail() {


### PR DESCRIPTION
Fixes #488.

When we reache the `**` node we're at the path segment it is going to match against. The `currentIndex` is incremented on [line 125](https://github.com/httpswift/swifter/blob/stable/Xcode/Sources/HttpRouter.swift#L125) which means that we're going to continue checking from the next segment over. So if we increment again before we go into the `while` loop we've skipped over one and will fail to match the end of the path against our pattern.