### PR TITLE
Fixed async array mutation on stop

### DIFF
--- a/Xcode/Sources/HttpServerIO.swift
+++ b/Xcode/Sources/HttpServerIO.swift
@@ -100,11 +100,11 @@ open class HttpServerIO {
     public func stop() {
         guard self.operating else { return }
         self.state = .stopping
-        // Shutdown connected peers because they can live in 'keep-alive' or 'websocket' loops.
-        for socket in self.sockets {
-            socket.close()
-        }
         self.queue.sync {
+            // Shutdown connected peers because they can live in 'keep-alive' or 'websocket' loops.
+            for socket in self.sockets {
+                socket.close()
+            }
             self.sockets.removeAll(keepingCapacity: true)
         }
         socket.close()


### PR DESCRIPTION
The sockets array looped through in the stop method can be modified asynchronously by the start method. This leads to a very rare crash (I wasn't able to reproduce it in a test case consistently, but it happened from time to time). It's most likely even recorded by Mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1608793