### PR TITLE
Async handling; Controller protocol; Path/handler conveniences

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -8,7 +8,7 @@ jobs:
   Test-Linux-Platform:
     runs-on: ubuntu-latest
     container:
-      image: swift:5.2
+      image: swift:5.6
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
         with:
-          xcode-version: 12.0
+          xcode-version: 13.2
       - uses: actions/checkout@v2
       - name: Create Test Result Directory
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,11 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
   name: "Swifter",
+
+  platforms: [.macOS(.v10_15)],
 
   products: [
     .library(name: "Swifter", targets: ["Swifter"]),
@@ -19,7 +21,7 @@ let package = Package(
       path: "Xcode/Sources"
       ),
 
-    .target(
+    .executableTarget(
       name: "SwifterExample",
       dependencies: [
         "Swifter"

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,9 @@ let package = Package(
     .target(
       name: "Swifter", 
       dependencies: [], 
-      path: "Xcode/Sources"
-      ),
+      path: "Xcode/Sources",
+      exclude: ["Xcode/Sources/DemoServer.swift"]
+    ),
 
     .executableTarget(
       name: "SwifterExample",

--- a/Xcode/Sources/Controller.swift
+++ b/Xcode/Sources/Controller.swift
@@ -1,0 +1,3 @@
+public protocol Controller {
+    init(request: HttpRequest)
+}

--- a/Xcode/Sources/Files.swift
+++ b/Xcode/Sources/Files.swift
@@ -81,7 +81,7 @@ public func directoryBrowser(_ dir: String) -> ((HttpRequest) -> HttpResponse) {
                                 tr {
                                     td {
                                         a {
-                                            href = request.path + "/" + file
+                                            href = request.path + "%2F" + file
                                             inner = file
                                         }
                                     }

--- a/Xcode/Sources/HttpRouter.swift
+++ b/Xcode/Sources/HttpRouter.swift
@@ -125,20 +125,21 @@ open class HttpRouter {
             var currentIndex = index + 1
             let variableNodes = node.nodes.filter { $0.0.first == ":" }
             if let variableNode = variableNodes.first {
+                let paramName = String(variableNode.0.dropFirst())
                 if currentIndex == count && variableNode.1.isEndOfRoute {
                     // if it's the last element of the pattern and it's a variable, stop the search and
                     // append a tail as a value for the variable.
                     let tail = pattern[currentIndex..<count].joined(separator: "/")
                     if tail.count > 0 {
-                        params[variableNode.0] = pathToken + "/" + tail
+                        params[paramName] = pathToken + "/" + tail
                     } else {
-                        params[variableNode.0] = pathToken
+                        params[paramName] = pathToken
                     }
 
                     matchedNodes.append(variableNode.value)
                     return
                 }
-                params[variableNode.0] = pathToken
+                params[paramName] = pathToken
                 findHandler(&node.nodes[variableNode.0]!, params: &params, pattern: pattern, matchedNodes: &matchedNodes, index: currentIndex, count: count)
             }
 

--- a/Xcode/Sources/HttpRouter.swift
+++ b/Xcode/Sources/HttpRouter.swift
@@ -20,7 +20,7 @@ open class HttpRouter {
         var isEndOfRoute: Bool = false
 
         /// The closure to handle the route
-        var handler: ((HttpRequest) -> HttpResponse)?
+        var handler: ((HttpRequest) async -> HttpResponse)?
     }
 
     private var rootNode = Node()
@@ -47,7 +47,7 @@ open class HttpRouter {
         return result
     }
 
-    public func register(_ method: String?, path: String, handler: ((HttpRequest) -> HttpResponse)?) {
+    public func register(_ method: String?, path: String, handler: ((HttpRequest) async -> HttpResponse)?) {
         var pathSegments = stripQuery(path).split("/")
         if let method = method {
             pathSegments.insert(method, at: 0)
@@ -58,7 +58,7 @@ open class HttpRouter {
         inflate(&rootNode, generator: &pathSegmentsGenerator).handler = handler
     }
 
-    public func route(_ method: String?, path: String) -> ([String: String], (HttpRequest) -> HttpResponse)? {
+    public func route(_ method: String?, path: String) -> ([String: String], (HttpRequest) async -> HttpResponse)? {
 
         return queue.sync {
             if let method = method {
@@ -98,7 +98,7 @@ open class HttpRouter {
         return currentNode
     }
 
-    private func findHandler(_ node: inout Node, params: inout [String: String], generator: inout IndexingIterator<[String]>) -> ((HttpRequest) -> HttpResponse)? {
+    private func findHandler(_ node: inout Node, params: inout [String: String], generator: inout IndexingIterator<[String]>) -> ((HttpRequest) async -> HttpResponse)? {
 
         var matchedRoutes = [Node]()
         let pattern = generator.map { $0 }

--- a/Xcode/Sources/HttpServer.swift
+++ b/Xcode/Sources/HttpServer.swift
@@ -74,18 +74,20 @@ open class HttpServer: HttpServerIO {
     public struct MethodRoute {
         public let method: String
         public let router: HttpRouter
-        public subscript(path: String) -> ((HttpRequest) async -> HttpResponse)? {
+        public subscript(paths: String...) -> ((HttpRequest) async -> HttpResponse)? {
             get { return nil }
             set {
-                router.register(method, path: path, handler: newValue)
+                paths.forEach { router.register(method, path: $0, handler: newValue) }
             }
         }
-        public subscript<T: Controller>(path: String) -> ((T) -> () async -> HttpResponse)? {
+        public subscript<T: Controller>(paths: String...) -> ((T) -> () async -> HttpResponse)? {
             get { nil }
             set {
                 guard let newValue = newValue else { return }
-                router.register(method, path: path) { request in
-                    await newValue(T(request: request))()
+                paths.forEach { path in
+                    router.register(method, path: path) { request in
+                        await newValue(T(request: request))()
+                    }
                 }
             }
         }

--- a/Xcode/Sources/HttpServer.swift
+++ b/Xcode/Sources/HttpServer.swift
@@ -41,7 +41,7 @@ open class HttpServer: HttpServerIO {
     public var DELETE, PATCH, HEAD, POST, GET, PUT: MethodRoute
     public var delete, patch, head, post, get, put: MethodRoute
 
-    public subscript(path: String) -> ((HttpRequest) -> HttpResponse)? {
+    public subscript(path: String) -> ((HttpRequest) async -> HttpResponse)? {
         get { return nil }
         set {
             router.register(nil, path: path, handler: newValue)
@@ -56,7 +56,7 @@ open class HttpServer: HttpServerIO {
 
     public var middleware = [(HttpRequest) -> HttpResponse?]()
 
-    override open func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) -> HttpResponse) {
+    override open func dispatch(_ request: HttpRequest) -> ([String: String], (HttpRequest) async -> HttpResponse) {
         for layer in middleware {
             if let response = layer(request) {
                 return ([:], { _ in response })
@@ -74,7 +74,7 @@ open class HttpServer: HttpServerIO {
     public struct MethodRoute {
         public let method: String
         public let router: HttpRouter
-        public subscript(path: String) -> ((HttpRequest) -> HttpResponse)? {
+        public subscript(path: String) -> ((HttpRequest) async -> HttpResponse)? {
             get { return nil }
             set {
                 router.register(method, path: path, handler: newValue)

--- a/Xcode/Sources/HttpServer.swift
+++ b/Xcode/Sources/HttpServer.swift
@@ -80,5 +80,14 @@ open class HttpServer: HttpServerIO {
                 router.register(method, path: path, handler: newValue)
             }
         }
+        public subscript<T: Controller>(path: String) -> ((T) -> () async -> HttpResponse)? {
+            get { nil }
+            set {
+                guard let newValue = newValue else { return }
+                router.register(method, path: path) { request in
+                    await newValue(T(request: request))()
+                }
+            }
+        }
     }
 }

--- a/Xcode/Tests/FilesTests.swift
+++ b/Xcode/Tests/FilesTests.swift
@@ -55,7 +55,7 @@ class FilesTests: XCTestCase {
         let closure = shareFile(temporaryDirectoryURL.appendingPathComponent("does_not_exist").path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
 
     func testShareFilesFromDirectory() {
@@ -77,7 +77,7 @@ class FilesTests: XCTestCase {
         let closure = shareFilesFromDirectory(temporaryDirectoryURL.path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
     
     func testDirectoryBrowser() {
@@ -95,6 +95,6 @@ class FilesTests: XCTestCase {
         let closure = directoryBrowser(temporaryDirectoryURL.path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
 }

--- a/Xcode/Tests/SwifterTestsHttpRouter.swift
+++ b/Xcode/Tests/SwifterTestsHttpRouter.swift
@@ -128,7 +128,7 @@ class SwifterTestsHttpRouter: XCTestCase {
         XCTAssertNotNil(router.route(nil, path: "/a/%3C%3E/%5E"))
     }
 
-    func testHttpRouterHandlesOverlappingPaths() {
+    func testHttpRouterHandlesOverlappingPaths() async {
 
         let request = HttpRequest()
 
@@ -151,19 +151,19 @@ class SwifterTestsHttpRouter: XCTestCase {
         let staticRouteResult = router.route("GET", path: "a/b")
         let staticRouterHandler = staticRouteResult?.1
         XCTAssertNotNil(staticRouteResult)
-        _ = staticRouterHandler?(request)
+        _ = await staticRouterHandler?(request)
 
         let variableRouteResult = router.route("GET", path: "a/b/c")
         let variableRouterHandler = variableRouteResult?.1
         XCTAssertNotNil(variableRouteResult)
-        _ = variableRouterHandler?(request)
+        _ = await variableRouterHandler?(request)
 
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         XCTAssertTrue(foundStaticRoute)
         XCTAssertTrue(foundVariableRoute)
     }
 
-    func testHttpRouterHandlesOverlappingPathsInDynamicRoutes() {
+    func testHttpRouterHandlesOverlappingPathsInDynamicRoutes() async {
 
         let request = HttpRequest()
 
@@ -186,19 +186,19 @@ class SwifterTestsHttpRouter: XCTestCase {
         let firstRouteResult = router.route("GET", path: "a/b")
         let firstRouterHandler = firstRouteResult?.1
         XCTAssertNotNil(firstRouteResult)
-        _ = firstRouterHandler?(request)
+        _ = await firstRouterHandler?(request)
 
         let secondRouteResult = router.route("GET", path: "a/b/c")
         let secondRouterHandler = secondRouteResult?.1
         XCTAssertNotNil(secondRouteResult)
-        _ = secondRouterHandler?(request)
+        _ = await secondRouterHandler?(request)
 
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         XCTAssertTrue(foundFirstVariableRoute)
         XCTAssertTrue(foundSecondVariableRoute)
     }
 
-    func testHttpRouterShouldHandleOverlappingRoutesInTrail() {
+    func testHttpRouterShouldHandleOverlappingRoutesInTrail() async {
 
         let request = HttpRequest()
 
@@ -229,25 +229,25 @@ class SwifterTestsHttpRouter: XCTestCase {
         let firstRouteResult = router.route("GET", path: "/a")
         let firstRouterHandler = firstRouteResult?.1
         XCTAssertNotNil(firstRouteResult)
-        _ = firstRouterHandler?(request)
+        _ = await firstRouterHandler?(request)
 
         let secondRouteResult = router.route("GET", path: "/a/b")
         let secondRouterHandler = secondRouteResult?.1
         XCTAssertNotNil(secondRouteResult)
-        _ = secondRouterHandler?(request)
+        _ = await secondRouterHandler?(request)
 
         let thirdRouteResult = router.route("GET", path: "/a/b/b")
         let thirdRouterHandler = thirdRouteResult?.1
         XCTAssertNotNil(thirdRouteResult)
-        _ = thirdRouterHandler?(request)
+        _ = await thirdRouterHandler?(request)
 
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         XCTAssertTrue(foundFirstVariableRoute)
         XCTAssertTrue(foundSecondVariableRoute)
         XCTAssertTrue(foundThirdVariableRoute)
     }
 
-    func testHttpRouterHandlesOverlappingPathsInDynamicRoutesInTheMiddle() {
+    func testHttpRouterHandlesOverlappingPathsInDynamicRoutesInTheMiddle() async {
 
         let request = HttpRequest()
 
@@ -270,14 +270,14 @@ class SwifterTestsHttpRouter: XCTestCase {
         let firstRouteResult = router.route("GET", path: "/a/b/c/d/e")
         let firstRouterHandler = firstRouteResult?.1
         XCTAssertNotNil(firstRouteResult)
-        _ = firstRouterHandler?(request)
+        _ = await firstRouterHandler?(request)
 
         let secondRouteResult = router.route("GET", path: "/a/b/f/g")
         let secondRouterHandler = secondRouteResult?.1
         XCTAssertNotNil(secondRouteResult)
-        _ = secondRouterHandler?(request)
+        _ = await secondRouterHandler?(request)
 
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         XCTAssertTrue(foundFirstVariableRoute)
         XCTAssertTrue(foundSecondVariableRoute)
     }


### PR DESCRIPTION
Hi there 👋 

This PR is mostly to gauge interest in a few changes I've made to a forked copy of this package. I can very easily split this up into many PRs if there is interest in any/all of this, but first wanted to see how it was received. Thanks for having a look!

## Included Changes
1. Support Async/Await
a. Allows use of async/await to make async extremely simple
1. Fix file dir handling
a. Noticed files within directories were broken
1. Exclude DemoServer from package
a. Slim out the package
1. Add controller protocol and convenience subscript
a. Allows `GET["your/route"] = MyController.myRouteHandler`
i. The above would be possible for the following: `struct MyController: Controller { func myRouteHandler(_ request: HttpRequest) async -> HttpResponse {`
1. Enable registering multiple paths for a given handler
a. Allows `GET["my/first/route", "my_other_route"] = { request in }`
1. Trim `:` from request parameters
a. Allows `request["parameterName"]` vs `request[":parameterName"]` as a more convenient/intuitive accessor.
i. Addresses #489 