### PR TITLE
fix(queue): moved socket iteration into queue

### DIFF
--- a/Xcode/Sources/HttpServerIO.swift
+++ b/Xcode/Sources/HttpServerIO.swift
@@ -100,11 +100,11 @@ open class HttpServerIO {
     public func stop() {
         guard self.operating else { return }
         self.state = .stopping
-        // Shutdown connected peers because they can live in 'keep-alive' or 'websocket' loops.
-        for socket in self.sockets {
-            socket.close()
-        }
         self.queue.sync {
+            // Shutdown connected peers because they can live in 'keep-alive' or 'websocket' loops.
+            for socket in self.sockets {
+                socket.close()
+            }
             self.sockets.removeAll(keepingCapacity: true)
         }
         socket.close()

--- a/Xcode/Tests/FilesTests.swift
+++ b/Xcode/Tests/FilesTests.swift
@@ -55,7 +55,7 @@ class FilesTests: XCTestCase {
         let closure = shareFile(temporaryDirectoryURL.appendingPathComponent("does_not_exist").path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
 
     func testShareFilesFromDirectory() {
@@ -77,7 +77,7 @@ class FilesTests: XCTestCase {
         let closure = shareFilesFromDirectory(temporaryDirectoryURL.path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
     
     func testDirectoryBrowser() {
@@ -95,6 +95,6 @@ class FilesTests: XCTestCase {
         let closure = directoryBrowser(temporaryDirectoryURL.path)
         let result = closure(request)
 
-        XCTAssert(result == .notFound)
+        XCTAssert(result == .notFound())
     }
 }


### PR DESCRIPTION
We have been experiencing issues with random test failure in Swifter's unit tests. Particularly `testStopWithActiveConnections` in `IOSafetyTests`

<img width="947" alt="Swifter Test Failure" src="https://user-images.githubusercontent.com/112673780/235822665-6c8bdee9-ab32-4926-a6fc-9510dc49aac6.png">

We believe this is due to `stop()` iterating through available `sockets` while they are potentially mutated by the global queue dispatch in `start()`. This PR moves the loop over `sockets` into the private queue to ensure that access is gated. It appears to fix our random failures with unit tests (so far 🤞)
